### PR TITLE
Hi yarrick, i have a bugfix for Mountain Lion.

### DIFF
--- a/src/tun.c
+++ b/src/tun.c
@@ -475,15 +475,19 @@ tun_setip(const char *ip, const char *other_ip, int netbits)
 	
 	fprintf(stderr, "Setting IP of %s to %s\n", if_name, ip);
 #ifndef LINUX
+	struct in_addr netip;
+	netip.s_addr = inet_addr(ip);
+	netip.s_addr = netip.s_addr & net.s_addr;
 	r = system(cmdline);
 	if(r != 0) {
 		return r;
 	} else {
+		
 		snprintf(cmdline, sizeof(cmdline),
 				"/sbin/route add %s/%d %s",
-				ip, netbits, ip);
+				inet_ntoa(netip), netbits, ip);
 	}
-	fprintf(stderr, "Adding route %s/%d to %s\n", ip, netbits, ip);
+	fprintf(stderr, "Adding route %s/%d to %s\n", inet_ntoa(netip), netbits, ip);
 #endif
 	return system(cmdline);
 #else /* WINDOWS32 */


### PR DESCRIPTION
after update to OSX 10.8 I've gotten these error:

route: writing to routing socket: Can't assign requested address
add net 192.168.99.2: gateway 192.168.99.2: Can't assign requested address

This change fix that!

I didn't test this version on other operating systems.

Best greetings,

Philipp
