### PR TITLE
Fix gcc warning -Wsizeof-pointer-memaccess

### DIFF
--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2023,7 +2023,7 @@ write_dns_nameenc(char *buf, size_t buflen, char *data, int datalen, char downen
 	space = MIN(0xFF, buflen) - 4 - 2;
 	/* -1 encoding type, -3 ".xy", -2 for safety */
 
-	memset(buf, 0, sizeof(buf));
+	memset(buf, 0, buflen);
 
 	if (downenc == 'S') {
 		buf[0] = 'i';


### PR DESCRIPTION
iodined.c: In function ‘write_dns_nameenc’:
iodined.c:2030:23: attention : argument to ‘sizeof’ in ‘memset’ call is the same
expression as the destination; did you mean to provide an explicit length? [-Wsizeof-pointer-memaccess]
  memset(buf, 0, sizeof(buf));

sizeof buf will just give the size of the pointer, while buflen will clean the whole
memory.
