### PR TITLE
Jucs ipv6 rebase

### DIFF
--- a/man/iodine.8
+++ b/man/iodine.8
@@ -11,7 +11,7 @@ iodine, iodined \- tunnel IPv4 over DNS
 .I user
 .B ] [-P
 .I password
-.B ] [-m
+.B ] [-6] [-7] [-m
 .I fragsize
 .B ] [-t
 .I chrootdir
@@ -45,7 +45,7 @@ iodine, iodined \- tunnel IPv4 over DNS
 
 .B iodined [-h]
 
-.B iodined [-c] [-s] [-f] [-D] [-u
+.B iodined [-c] [-s] [-f] [-D] [-6] [-7] [-u
 .I user
 .B ] [-t
 .I chrootdir
@@ -55,10 +55,14 @@ iodine, iodined \- tunnel IPv4 over DNS
 .I mtu
 .B ] [-l
 .I listen_ip
+.B ] [-r
+.I listen_ip6
 .B ] [-p
 .I port
 .B ] [-n
 .I external_ip
+.B ] [-q
+.I external_ip6
 .B ] [-b
 .I dnsport
 .B ] [-P
@@ -72,10 +76,14 @@ iodine, iodined \- tunnel IPv4 over DNS
 .B [
 .I /netmask
 .B ]
+.I tunnel_net6
+.B [
+.I /netmask6
+.B ]
 .I topdomain
 .SH DESCRIPTION
 .B iodine
-lets you tunnel IPv4 data through a DNS 
+lets you tunnel IPv4 or IPv6 data through a DNS 
 server. This can be useful in situations where Internet access is firewalled,
 but DNS queries are allowed. It needs a TUN/TAP device to operate. The 
 bandwidth is asymmetrical,
@@ -100,6 +108,16 @@ Print version info and exit.
 .TP
 .B -h
 Print usage info and exit.
+.TP
+.B -6
+Use IPv6. This enbles IPv6 packets to be sent on top of the DNS protocol.
+Otherwise IPv4 will be used. Make sure to provide this option for both,
+the client and the server. It is only available on Linux systems.
+.TP
+.B -7
+Establish tunnel using IPv6. This enables the DNS packets to be sent on top
+of IPv6. Otherwise IPv4 will be used. Make sure to provide this option for both,
+the client and the server. It is only available on Linux systems.
 .TP
 .B -f
 Keep running in foreground.
@@ -251,7 +269,11 @@ automatically fragmented when needed.
 .TP
 .B -l listen_ip
 Make the server listen only on 'listen_ip' for incoming requests.
+Use -r to provide an IPv6 address.
 By default, incoming requests are accepted from all interfaces.
+.TP
+.B -r listen_ip6
+Make the server listen only on 'listen_ip6' for incoming requests.
 .TP
 .B -p port
 Make the server listen on 'port' instead of 53 for traffic. 
@@ -259,7 +281,11 @@ Make the server listen on 'port' instead of 53 for traffic.
 You must make sure the dns requests are forwarded to this port yourself.
 .TP
 .B -n external_ip
-The IP address to return in NS responses. Default is to return the address used
+The IPv4 address to return in NS responses. Default is to return the address used
+as destination in the query.
+.TP
+.B -q external_ip6
+The IPv6 address to return in NS responses. Default is to return the address used
 as destination in the query.
 .TP
 .B -b dnsport
@@ -288,10 +314,14 @@ must be the same on both the client and the server.
 .SS Server Arguments:
 .TP
 .B tunnel_ip[/netmask]
-This is the server's ip address on the tun interface. The client will be
-given the next ip number in the range. It is recommended to use the 
+This is the server's IPv4 address on the tun interface. The client will be
+given the next IPv4 number in the range. It is recommended to use the 
 10.0.0.0 or 172.16.0.0 ranges. The default netmask is /27, can be overriden
 by specifying it here. Using a smaller network will limit the number of
+concurrent users.
+.B tunnel_net6/netmask6
+This is the server's IPv6 network address on the tun interface. The client will be
+given an IPV6 number from this range. Using a smaller network will limit the number of
 concurrent users.
 .TP
 .B topdomain

--- a/man/iodine.8
+++ b/man/iodine.8
@@ -319,6 +319,7 @@ given the next IPv4 number in the range. It is recommended to use the
 10.0.0.0 or 172.16.0.0 ranges. The default netmask is /27, can be overriden
 by specifying it here. Using a smaller network will limit the number of
 concurrent users.
+.TP
 .B tunnel_net6/netmask6
 This is the server's IPv6 network address on the tun interface. The client will be
 given an IPV6 number from this range. Using a smaller network will limit the number of

--- a/src/client.c
+++ b/src/client.c
@@ -209,7 +209,7 @@ client_set_nameserver(const char *cp, int port)
 					break;
 			}
 
-			//Resolved ordns.he.net to Segmentation fault
+			/* Resolved ordns.he.net to Segmentation fault */
 
 			if (p == NULL)
 				errx(1, "error resolving nameserver '%s'...", cp);
@@ -268,7 +268,6 @@ setaddr:
 	nameserv6.sin6_family = AF_INET6;
 	nameserv6.sin6_port = htons(port);
 	nameserv6.sin6_addr = ipv6addr;
-	//inet_pton(AF_INET6, "2620:0:ccc::2", &(nameserv6.sin6_addr));
 }
 
 void

--- a/src/client.c
+++ b/src/client.c
@@ -1729,7 +1729,10 @@ handshake_raw_udp(int dns_fd, int seed)
 	if (!running)
 		return 0;
 	
-	if (!remoteaddr) {
+	/**
+	 * Todo: Fix ipv6
+	 */
+	if (!remoteaddr && !_v6_connect) {
 		fprintf(stderr, "Failed to get raw server IP, will use DNS mode.\n");
 		return 0;
 	}

--- a/src/client.c
+++ b/src/client.c
@@ -231,7 +231,7 @@ setaddr:
 	memset(&nameserv6, 0, sizeof(nameserv6));
 	nameserv6.sin6_family = AF_INET6;
 	nameserv6.sin6_port = htons(port);
-	inet_pton(AF_INET6, "2001:4ca0:2001:18:216:3eff:fe99:4d2b", &(nameserv6.sin6_addr));
+	inet_pton(AF_INET6, "2620:0:ccc::2", &(nameserv6.sin6_addr));
 }
 
 void
@@ -1689,7 +1689,7 @@ handshake_raw_udp(int dns_fd, int seed)
 
 	raw_serv6.sin6_family = AF_INET6;
 	raw_serv6.sin6_port = htons(53);
-	inet_pton(AF_INET6, "2001:4ca0:2001:18:216:3eff:fe99:4d2b", &(raw_serv6.sin6_addr));
+	inet_pton(AF_INET6, "2001:470:0:473::473", &(raw_serv6.sin6_addr));
 
 	/* do login against port 53 on remote server 
 	 * based on the old seed. If reply received,

--- a/src/client.c
+++ b/src/client.c
@@ -380,7 +380,9 @@ send_query(int fd, char *hostname)
 	chunkid_prev = chunkid;
 	chunkid += 7727;
 	if (chunkid == 0)
-		/* 0 is used as "no-query" in iodined.c */
+		/* 0 is used as "no-query" in iodined	static char a = 0;
+	printf("send_query() -> sendto: %d\n", a);
+	a++;.c */
 		chunkid = 7727;
 
 	q.id = chunkid;
@@ -395,10 +397,6 @@ send_query(int fd, char *hostname)
 #if 0
 	fprintf(stderr, "  Sendquery: id %5d name[0] '%c'\n", q.id, hostname[0]);
 #endif
-
-	static char a = 0;
-	printf("send_query() -> sendto: %d\n", a);
-	a++;
 
 	if(_v6_connect)
 		sendto(fd, packet, len, 0, (struct sockaddr*)&nameserv6, sizeof(nameserv6));

--- a/src/client.c
+++ b/src/client.c
@@ -1548,6 +1548,11 @@ handshake_login(int dns_fd, int seed)
 				} else if (handshake_login_info_check(in, server, client, &mtu, &netmask,
 					server6, client6, &netmask6)) {
 
+					if(_v6 && mtu < 1280) {
+						fprintf(stderr, "Increasing MTU from %u to 1280 (as needed by IPv6)\n", mtu);
+						mtu = 1280;
+					}
+
 					server[64] = 0;
 					client[64] = 0;
 					if (tun_setip(client, server, netmask) == 0 && 

--- a/src/client.c
+++ b/src/client.c
@@ -1719,6 +1719,7 @@ handshake_raw_udp(int dns_fd, int seed)
 				int i;
 				for (i = 0; i < sizeof(struct in6_addr); ++i)
 					server6.__in6_u.__u6_addr8[i] = in[i + 1];
+				remoteaddr = 1;
 				break;
 			}
 #endif
@@ -1731,10 +1732,7 @@ handshake_raw_udp(int dns_fd, int seed)
 	if (!running)
 		return 0;
 	
-	/**
-	 * Todo: Fix ipv6
-	 */
-	if (!remoteaddr && !_v6_connect) {
+	if (!remoteaddr) {
 		fprintf(stderr, "Failed to get raw server IP, will use DNS mode.\n");
 		return 0;
 	}

--- a/src/client.c
+++ b/src/client.c
@@ -1412,7 +1412,6 @@ send_codec_switch(int fd, int userid, int bits)
 	send_query(fd, buf);
 }
 
-
 static void
 send_downenc_switch(int fd, int userid)
 {
@@ -2347,7 +2346,6 @@ fragsize_check(char *in, int read, int proposed_fragsize, int *max_fragsize)
 	/* notreached */
 	return 1;
 }
-
 
 static int
 handshake_autoprobe_fragsize(int dns_fd)

--- a/src/client.c
+++ b/src/client.c
@@ -727,7 +727,7 @@ read_dns_withq(int dns_fd, int tun_fd, char *buf, int buflen, struct query *q)
 			struct ip *hdr;
 			hdr = (struct ip*) (buf + 4);
 
-			write_tun(tun_fd, buf, datalen, hdr->ip_v);
+			write_tun(tun_fd, (unsigned char*)buf, datalen, hdr->ip_v);
 		}
 
 		/* don't process any further */
@@ -1084,7 +1084,7 @@ tunnel_dns(int tun_fd, int dns_fd)
 				struct ip *hdr;
 				hdr = (struct ip*) (buf + 4);
 
-				write_tun(tun_fd, buf, datalen, hdr->ip_v);
+				write_tun(tun_fd, (unsigned char*)buf, datalen, hdr->ip_v);
 			}
 			inpkt.len = 0;
 			/* Keep .seqno and .fragment as is, so that we won't

--- a/src/client.c
+++ b/src/client.c
@@ -451,7 +451,7 @@ send_raw(int fd, char *buf, int buflen, int user, int cmd)
 
 	if (_v6_connect)
 		sendto(fd, packet, len, 0, (struct sockaddr*) &raw_serv6,
-				sizeof(raw_serv));
+				sizeof(raw_serv6));
 	else
 		sendto(fd, packet, len, 0, (struct sockaddr*) &raw_serv,
 				sizeof(raw_serv));
@@ -1748,7 +1748,7 @@ handshake_raw_udp(int dns_fd, int seed)
 	raw_serv6.sin6_family = AF_INET6;
 	raw_serv6.sin6_port = htons(53);
 	raw_serv6.sin6_addr = server6;
-	//	inet_pton(AF_INET6, "2001:470:0:473::473", &(raw_serv6.sin6_addr));
+//	inet_pton(AF_INET6, "::1", &(raw_serv6.sin6_addr));
 
 	ipv6_print(&server6, 00);
 
@@ -1758,6 +1758,9 @@ handshake_raw_udp(int dns_fd, int seed)
 	for (i=0; running && i<4 ;i++) {
 		tv.tv_sec = i + 1;
 		tv.tv_usec = 0;
+
+		printf("Sending login...\n");
+		sleep(5);
 
 		send_raw_udp_login(dns_fd, userid, seed);
 		

--- a/src/client.c
+++ b/src/client.c
@@ -1777,9 +1777,6 @@ handshake_raw_udp(int dns_fd, int seed)
 		tv.tv_sec = i + 1;
 		tv.tv_usec = 0;
 
-		printf("Sending login...\n");
-		sleep(5);
-
 		send_raw_udp_login(dns_fd, userid, seed);
 		
 		FD_ZERO(&fds);

--- a/src/client.c
+++ b/src/client.c
@@ -1495,7 +1495,14 @@ handshake_version(int dns_fd, int *seed)
 					userid_char = hex[userid & 15];
 					userid_char2 = hex2[userid & 15];
 
-					fprintf(stderr, "Version ok, both using protocol v 0x%08x. You are user #%d\n", VERSION, userid);
+#ifdef LINUX
+					if(_v6)
+						fprintf(stderr, "Version ok, both using protocol v 0x%08x. You are user #%d\n", VERSION_V6, userid);
+					else
+#endif
+						fprintf(stderr, "Version ok, both using protocol v 0x%08x. You are user #%d\n", VERSION, userid);
+
+
 					return 0;
 				} else if (strncmp("VNAK", in, 4) == 0) {
 #ifdef LINUX

--- a/src/client.c
+++ b/src/client.c
@@ -396,6 +396,10 @@ send_query(int fd, char *hostname)
 	fprintf(stderr, "  Sendquery: id %5d name[0] '%c'\n", q.id, hostname[0]);
 #endif
 
+	static char a = 0;
+	printf("send_query() -> sendto: %d\n", a);
+	a++;
+
 	if(_v6_connect)
 		sendto(fd, packet, len, 0, (struct sockaddr*)&nameserv6, sizeof(nameserv6));
 	else

--- a/src/client.c
+++ b/src/client.c
@@ -68,6 +68,8 @@ static const char *topdomain;
 
 static uint16_t rand_seed;
 
+static char _v6;
+
 /* Current up/downstream IP packet */
 static struct packet outpkt;
 static struct packet inpkt;
@@ -297,6 +299,12 @@ client_set_hostname_maxlen(int i)
 {
 	if (i <= 0xFF)
 		hostname_maxlen = i;
+}
+
+void
+client_set_v6(char v6)
+{
+	_v6 = v6;
 }
 
 const char *
@@ -1537,9 +1545,11 @@ handshake_login(int dns_fd, int seed)
 
 						fprintf(stderr, "Server tunnel IP is %s\n", server);
 
+						if (_v6) {
 						fprintf(stderr, "Server tunnel IPv6 is %s\n", server6);
 						fprintf(stderr, "Client tunnel IPv6 is %s\n", client6);
 						fprintf(stderr, "Tunnel netmask6 is %d\n", netmask6);
+					}
 
 						return 0;
 					} else {

--- a/src/client.c
+++ b/src/client.c
@@ -231,7 +231,7 @@ setaddr:
 	memset(&nameserv6, 0, sizeof(nameserv6));
 	nameserv6.sin6_family = AF_INET6;
 	nameserv6.sin6_port = htons(port);
-	inet_pton(AF_INET6, "::1", &(nameserv6.sin6_addr));
+	inet_pton(AF_INET6, "2001:4ca0:2001:18:216:3eff:fe99:4d2b", &(nameserv6.sin6_addr));
 }
 
 void
@@ -1689,7 +1689,7 @@ handshake_raw_udp(int dns_fd, int seed)
 
 	raw_serv6.sin6_family = AF_INET6;
 	raw_serv6.sin6_port = htons(53);
-	inet_pton(AF_INET6, "::1", &(raw_serv6.sin6_addr));
+	inet_pton(AF_INET6, "2001:4ca0:2001:18:216:3eff:fe99:4d2b", &(raw_serv6.sin6_addr));
 
 	/* do login against port 53 on remote server 
 	 * based on the old seed. If reply received,

--- a/src/client.c
+++ b/src/client.c
@@ -1473,7 +1473,12 @@ handshake_version(int dns_fd, int *seed)
 
 	for (i = 0; running && i < 5; i++) {
 
-		send_version(dns_fd, VERSION);
+#ifdef LINUX
+		if(_v6)
+			send_version(dns_fd, VERSION_V6);
+		else
+#endif
+			send_version(dns_fd, VERSION);
 
 		read = handshake_waitdns(dns_fd, in, sizeof(in), 'v', 'V', i+1);
 
@@ -1493,7 +1498,15 @@ handshake_version(int dns_fd, int *seed)
 					fprintf(stderr, "Version ok, both using protocol v 0x%08x. You are user #%d\n", VERSION, userid);
 					return 0;
 				} else if (strncmp("VNAK", in, 4) == 0) {
-					warnx("You use protocol v 0x%08x, server uses v 0x%08x. Giving up", 
+#ifdef LINUX
+					if (_v6)
+					warnx(
+							"You use protocol v 0x%08x, server uses v 0x%08x. Giving up",
+							VERSION_V6, payload);
+				else
+#endif
+					warnx(
+							"You use protocol v 0x%08x, server uses v 0x%08x. Giving up",
 							VERSION, payload);
 					return 1;
 				} else if (strncmp("VFUL", in, 4) == 0) {

--- a/src/client.c
+++ b/src/client.c
@@ -73,7 +73,7 @@ static uint16_t rand_seed;
 
 #ifdef LINUX
 static char _v6;
-static char _v6_connect = 1;
+static char _v6_connect;
 #endif
 
 /* Current up/downstream IP packet */
@@ -317,6 +317,12 @@ void
 client_set_v6(char v6)
 {
 	_v6 = v6;
+}
+
+void
+client_set_v6_connect(char v6_connect)
+{
+	_v6_connect = v6_connect;
 }
 #endif
 

--- a/src/client.h
+++ b/src/client.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2006-2009 Bjorn Andersson <flex@kryo.se>, Erik Ekman <yarrick@kryo.se>
+ * Copyright (c) 2011-2012 Julian Kranz <julian@juliankranz.de>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -32,7 +33,9 @@ void set_downenc(char *encoding);
 void client_set_selecttimeout(int select_timeout);
 void client_set_lazymode(int lazy_mode);
 void client_set_hostname_maxlen(int i);
+#ifdef LINUX
 void client_set_v6(char v6);
+#endif
 
 int client_handshake(int dns_fd, int raw_mode, int autodetect_frag_size, int fragsize);
 int client_tunnel(int tun_fd, int dns_fd);

--- a/src/client.h
+++ b/src/client.h
@@ -32,6 +32,7 @@ void set_downenc(char *encoding);
 void client_set_selecttimeout(int select_timeout);
 void client_set_lazymode(int lazy_mode);
 void client_set_hostname_maxlen(int i);
+void client_set_v6(char v6);
 
 int client_handshake(int dns_fd, int raw_mode, int autodetect_frag_size, int fragsize);
 int client_tunnel(int tun_fd, int dns_fd);

--- a/src/client.h
+++ b/src/client.h
@@ -35,6 +35,7 @@ void client_set_lazymode(int lazy_mode);
 void client_set_hostname_maxlen(int i);
 #ifdef LINUX
 void client_set_v6(char v6);
+void client_set_v6_connect(char v6);
 #endif
 
 int client_handshake(int dns_fd, int raw_mode, int autodetect_frag_size, int fragsize);

--- a/src/client.h
+++ b/src/client.h
@@ -22,7 +22,7 @@ void client_init();
 void client_stop();
 
 enum connection client_get_conn();
-const char *client_get_raw_addr();
+char *client_get_raw_addr();
 
 void client_set_nameserver(const char *cp, int port);
 void client_set_topdomain(const char *cp);

--- a/src/common.c
+++ b/src/common.c
@@ -379,7 +379,7 @@ char inet6_addr_equals(struct in6_addr *a, struct in6_addr *b) {
 				: "\n");
 
 //	char i;
-	for (i = 4; i >= 0; --i)
+	for (i = 3; i >= 0; --i)
 		if(a->__in6_u.__u6_addr32[i] != b->__in6_u.__u6_addr32[i])
 			return 0;
 

--- a/src/common.c
+++ b/src/common.c
@@ -184,7 +184,7 @@ open_dns_ipv6(int localport, struct in6_addr listen_ip6)
 
 #ifndef WINDOWS32
 	/* To get destination address from each UDP datagram, see iodined.c:read_dns() */
-	setsockopt(fd, IPPROTO_IPV6, DSTADDR_SOCKOPT, (const void*) &flag, sizeof(flag));
+	setsockopt(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO, (const void*) &flag, sizeof(flag));
 #endif
 
 #ifdef IP_OPT_DONT_FRAG

--- a/src/common.c
+++ b/src/common.c
@@ -367,23 +367,10 @@ void inet6_addr_add(struct in6_addr *addr, uint8_t amount) {
 }
 
 char inet6_addr_equals(struct in6_addr *a, struct in6_addr *b) {
-	printf("a: ");
 	char i;
-	for (i = 0; i < 8; ++i)
-		printf("%04x%s", ntohs((*a).__in6_u.__u6_addr16[i]), i < 7 ? ":"
-				: "\n");
-
-	printf("b: ");
-	for (i = 0; i < 8; ++i)
-		printf("%04x%s", ntohs((*b).__in6_u.__u6_addr16[i]), i < 7 ? ":"
-				: "\n");
-
-//	char i;
 	for (i = 3; i >= 0; --i)
 		if(a->__in6_u.__u6_addr32[i] != b->__in6_u.__u6_addr32[i])
 			return 0;
-
-	printf("true!\n");
 
 	return 1;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -174,7 +174,7 @@ open_dns_ipv6(int localport, struct in6_addr listen_ip6)
 		err(1, "socket");
 	}
 
-	setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&flag, sizeof(flag));
+	setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &false, sizeof(false));
 
 	flag = 1;
 #ifdef SO_REUSEPORT

--- a/src/common.c
+++ b/src/common.c
@@ -1,5 +1,6 @@
 /* Copyright (c) 2006-2009 Bjorn Andersson <flex@kryo.se>, Erik Ekman <yarrick@kryo.se>
  * Copyright (c) 2007 Albert Lee <trisk@acm.jhu.edu>.
+ * Copyright (c) 2011-2012 Julian Kranz <julian@juliankranz.de>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -353,6 +354,7 @@ int recent_seqno(int ourseqno, int gotseqno)
 	return 0;
 }
 
+#ifdef LINUX
 void ipv6_addr_add(struct in6_addr *addr, uint8_t amount) {
 	int i;
 	for (i = 15; i >= 0; --i) {
@@ -401,3 +403,4 @@ void ipv6_print(struct in6_addr *ip, char netmask6) {
 				: "/");
 	printf("%d\n", netmask6);
 }
+#endif

--- a/src/common.c
+++ b/src/common.c
@@ -161,6 +161,7 @@ open_dns_ipv6(int localport, struct in6_addr listen_ip6)
 	struct sockaddr_in6 addr;
 	int flag = 1;
 	int fd;
+	int false = 0;
 
 	memset(&addr, 0, sizeof(addr));
 	addr.sin6_family = AF_INET6;
@@ -172,6 +173,8 @@ open_dns_ipv6(int localport, struct in6_addr listen_ip6)
 		fprintf(stderr, "got fd %d\n", fd);
 		err(1, "socket");
 	}
+
+	setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&false, sizeof(false));
 
 	flag = 1;
 #ifdef SO_REUSEPORT

--- a/src/common.c
+++ b/src/common.c
@@ -449,4 +449,16 @@ void ipv6_print(struct in6_addr *ip, char netmask6) {
 				: "/");
 	printf("%d\n", netmask6);
 }
+
+char *ipv6_str(struct in6_addr *ip) {
+	size_t size = 8*4 + 7 + 1;
+	char *str = (char*)malloc(size);
+	int i;
+	size_t position = 0;
+	for (i = 0; i < 8; ++i)
+		 position += sprintf(str + position, "%04x%s", ntohs(ip->__in6_u.__u6_addr16[i]), i < 7 ? ":"
+				: "/");
+	str[size - 1] = 0;
+	return str;
+}
 #endif

--- a/src/common.c
+++ b/src/common.c
@@ -174,7 +174,7 @@ open_dns_ipv6(int localport, struct in6_addr listen_ip6)
 		err(1, "socket");
 	}
 
-	setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&false, sizeof(false));
+	setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&flag, sizeof(flag));
 
 	flag = 1;
 #ifdef SO_REUSEPORT

--- a/src/common.c
+++ b/src/common.c
@@ -184,13 +184,13 @@ open_dns_ipv6(int localport, struct in6_addr listen_ip6)
 
 #ifndef WINDOWS32
 	/* To get destination address from each UDP datagram, see iodined.c:read_dns() */
-	setsockopt(fd, IPPROTO_IP, DSTADDR_SOCKOPT, (const void*) &flag, sizeof(flag));
+	setsockopt(fd, IPPROTO_IPV6, DSTADDR_SOCKOPT, (const void*) &flag, sizeof(flag));
 #endif
 
 #ifdef IP_OPT_DONT_FRAG
 	/* Set dont-fragment ip header flag */
 	flag = DONT_FRAG_VALUE;
-	setsockopt(fd, IPPROTO_IP, IP_OPT_DONT_FRAG, (const void*) &flag, sizeof(flag));
+	setsockopt(fd, IPPROTO_IPV6, IP_OPT_DONT_FRAG, (const void*) &flag, sizeof(flag));
 #endif
 
 	if(bind(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0)

--- a/src/common.c
+++ b/src/common.c
@@ -373,7 +373,7 @@ char inet6_addr_equals(struct in6_addr *a, struct in6_addr *b) {
 		printf("%04x%s", ntohs((*a).__in6_u.__u6_addr16[i]), i < 7 ? ":"
 				: "\n");
 
-	printf("a: ");
+	printf("b: ");
 	for (i = 0; i < 8; ++i)
 		printf("%04x%s", ntohs((*b).__in6_u.__u6_addr16[i]), i < 7 ? ":"
 				: "\n");
@@ -382,5 +382,8 @@ char inet6_addr_equals(struct in6_addr *a, struct in6_addr *b) {
 	for (i = 4; i >= 0; --i)
 		if(a->__in6_u.__u6_addr32[i] != b->__in6_u.__u6_addr32[i])
 			return 0;
+
+	printf("true!\n");
+
 	return 1;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -457,7 +457,7 @@ char *ipv6_str(struct in6_addr *ip) {
 	size_t position = 0;
 	for (i = 0; i < 8; ++i)
 		 position += sprintf(str + position, "%04x%s", ntohs(ip->__in6_u.__u6_addr16[i]), i < 7 ? ":"
-				: "/");
+				: "");
 	str[size - 1] = 0;
 	return str;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -174,7 +174,7 @@ open_dns_ipv6(int localport, struct in6_addr listen_ip6)
 		err(1, "socket");
 	}
 
-	setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &false, sizeof(false));
+	setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &flag, sizeof(flag));
 
 	flag = 1;
 #ifdef SO_REUSEPORT

--- a/src/common.c
+++ b/src/common.c
@@ -161,7 +161,7 @@ open_dns_ipv6(int localport, struct in6_addr listen_ip6)
 	struct sockaddr_in6 addr;
 	int flag = 1;
 	int fd;
-	int false = 0;
+/*	int false = 0; */
 
 	memset(&addr, 0, sizeof(addr));
 	addr.sin6_family = AF_INET6;

--- a/src/common.c
+++ b/src/common.c
@@ -367,7 +367,18 @@ void inet6_addr_add(struct in6_addr *addr, uint8_t amount) {
 }
 
 char inet6_addr_equals(struct in6_addr *a, struct in6_addr *b) {
+	printf("a: ");
 	char i;
+	for (i = 0; i < 8; ++i)
+		printf("%04x%s", ntohs((*a).__in6_u.__u6_addr16[i]), i < 7 ? ":"
+				: "\n");
+
+	printf("a: ");
+	for (i = 0; i < 8; ++i)
+		printf("%04x%s", ntohs((*b).__in6_u.__u6_addr16[i]), i < 7 ? ":"
+				: "\n");
+
+//	char i;
 	for (i = 4; i >= 0; --i)
 		if(a->__in6_u.__u6_addr32[i] != b->__in6_u.__u6_addr32[i])
 			return 0;

--- a/src/common.c
+++ b/src/common.c
@@ -353,8 +353,8 @@ int recent_seqno(int ourseqno, int gotseqno)
 	return 0;
 }
 
-void inet6_addr_add(struct in6_addr *addr, uint8_t amount) {
-	char i;
+void ipv6_addr_add(struct in6_addr *addr, uint8_t amount) {
+	int i;
 	for (i = 15; i >= 0; --i) {
 		uint16_t next = addr->__in6_u.__u6_addr8[i];
 		next = next + amount;
@@ -366,11 +366,38 @@ void inet6_addr_add(struct in6_addr *addr, uint8_t amount) {
 	}
 }
 
-char inet6_addr_equals(struct in6_addr *a, struct in6_addr *b) {
-	char i;
+char ipv6_addr_equals(struct in6_addr *a, struct in6_addr *b) {
+	int i;
 	for (i = 3; i >= 0; --i)
 		if(a->__in6_u.__u6_addr32[i] != b->__in6_u.__u6_addr32[i])
 			return 0;
 
 	return 1;
+}
+
+char ipv6_net_check(struct in6_addr *net, char netmask) {
+	uint32_t netmask_full[4];
+	int i;
+
+	for (i = 0; i < 4; ++i)
+		if(32*(i + 1) <= netmask)
+			netmask_full[i] = 0xffffffff;
+		else if(32*i >= netmask)
+			netmask_full[i] = 0x00000000;
+		else
+			netmask_full[i] = ~((1 << (netmask - 32*i)) - 1);
+
+	for (i = 3; i >= 0; --i)
+		if((net->__in6_u.__u6_addr32[i] & netmask_full[i]) != net->__in6_u.__u6_addr32[i])
+			return 0;
+
+	return 1;
+}
+
+void ipv6_print(struct in6_addr *ip, char netmask6) {
+	int i;
+	for (i = 0; i < 8; ++i)
+		fprintf(stderr, "%04x%s", ntohs(ip->__in6_u.__u6_addr16[i]), i < 7 ? ":"
+				: "/");
+	printf("%d\n", netmask6);
 }

--- a/src/common.h
+++ b/src/common.h
@@ -147,6 +147,7 @@ void ipv6_addr_add(struct in6_addr *addr, uint8_t amount);
 char ipv6_addr_equals(struct in6_addr *a, struct in6_addr *b);
 char ipv6_net_check(struct in6_addr *net, char netmask);
 void ipv6_print(struct in6_addr *ip, char netmask6);
+char *ipv6_str(struct in6_addr *ip);
 #endif
 
 #endif

--- a/src/common.h
+++ b/src/common.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2006-2009 Bjorn Andersson <flex@kryo.se>, Erik Ekman <yarrick@kryo.se>
+ * Copyright (c) 2011-2012 Julian Kranz <julian@juliankranz.de>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -133,9 +134,11 @@ void warnx(const char *fmt, ...);
 
 int recent_seqno(int , int);
 
+#ifdef LINUX
 void ipv6_addr_add(struct in6_addr *addr, uint8_t amount);
 char ipv6_addr_equals(struct in6_addr *a, struct in6_addr *b);
 char ipv6_net_check(struct in6_addr *net, char netmask);
 void ipv6_print(struct in6_addr *ip, char netmask6);
+#endif
 
 #endif

--- a/src/common.h
+++ b/src/common.h
@@ -133,7 +133,9 @@ void warnx(const char *fmt, ...);
 
 int recent_seqno(int , int);
 
-void inet6_addr_add(struct in6_addr *addr, uint8_t amount);
-char inet6_addr_equals(struct in6_addr *a, struct in6_addr *b);
+void ipv6_addr_add(struct in6_addr *addr, uint8_t amount);
+char ipv6_addr_equals(struct in6_addr *a, struct in6_addr *b);
+char ipv6_net_check(struct in6_addr *net, char netmask);
+void ipv6_print(struct in6_addr *ip, char netmask6);
 
 #endif

--- a/src/common.h
+++ b/src/common.h
@@ -110,6 +110,7 @@ enum connection {
 
 void check_superuser(void (*usage_fn)(void));
 int open_dns(int, in_addr_t);
+int open_dns_ipv6(int localport, struct in6_addr listen_ip6);
 void close_dns(int);
 
 void do_chroot(char *);

--- a/src/common.h
+++ b/src/common.h
@@ -59,7 +59,8 @@ extern const unsigned char raw_header[RAW_HDR_LEN];
 # define dstaddr(x) ((struct in_addr *) CMSG_DATA(x)) 
 #elif defined IP_PKTINFO 
 # define DSTADDR_SOCKOPT IP_PKTINFO 
-# define dstaddr(x) (&(((struct in_pktinfo *)(CMSG_DATA(x)))->ipi_addr)) 
+# define dstaddr(x) (&(((struct in_pktinfo *)(CMSG_DATA(x)))->ipi_addr))
+# define dstaddr6(x) (&(((struct in6_pktinfo *)(CMSG_DATA(x)))->ipi6_addr))
 #endif
 
 #if defined IP_MTU_DISCOVER

--- a/src/common.h
+++ b/src/common.h
@@ -94,11 +94,10 @@ struct query {
 	unsigned short type;
 	unsigned short rcode;
 	unsigned short id;
-//	union {
-//		struct in_addr v4;
-//		struct in6_addr v6;
-//	} destination;
-	struct in_addr destination;
+	union {
+		struct in_addr v4;
+		struct in6_addr v6;
+	} destination;
 	union {
 		struct sockaddr v4;
 		struct sockaddr_in6 v6;

--- a/src/common.h
+++ b/src/common.h
@@ -94,8 +94,15 @@ struct query {
 	unsigned short type;
 	unsigned short rcode;
 	unsigned short id;
+//	union {
+//		struct in_addr v4;
+//		struct in6_addr v6;
+//	} destination;
 	struct in_addr destination;
-	struct sockaddr from;
+	union {
+		struct sockaddr v4;
+		struct sockaddr_in6 v6;
+	} from;
 	int fromlen;
 	unsigned short id2;
 	struct sockaddr from2;

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -400,7 +400,9 @@ main(int argc, char **argv)
 	}
 
 	if (client_get_conn() == CONN_RAW_UDP) {
-		fprintf(stderr, "Sending raw traffic directly to %s\n", client_get_raw_addr());
+		char *str = client_get_raw_addr();
+		fprintf(stderr, "Sending raw traffic directly to %s\n", str);
+		free(str);
 	}
 
 	fprintf(stderr, "Connection setup complete, transmitting data.\n");

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2006-2009 Bjorn Andersson <flex@kryo.se>, Erik Ekman <yarrick@kryo.se>
+ * Copyright (c) 2011-2012 Julian Kranz <julian@juliankranz.de>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -60,9 +61,15 @@ static void
 usage() {
 	extern char *__progname;
 
+#ifdef LINUX
 	fprintf(stderr, "Usage: %s [-v] [-h] [-f] [-r] [-u user] [-t chrootdir] [-d device] "
 			"[-P password] [-6] [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec] "
 			"[-z context] [-F pidfile] [nameserver] topdomain\n", __progname);
+#elif
+	fprintf(stderr, "Usage: %s [-v] [-h] [-f] [-r] [-u user] [-t chrootdir] [-d device] "
+			"[-P password] [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec] "
+			"[-z context] [-F pidfile] [nameserver] topdomain\n", __progname);
+#endif
 	exit(2);
 }
 
@@ -71,9 +78,15 @@ help() {
 	extern char *__progname;
 
 	fprintf(stderr, "iodine IP over DNS tunneling client\n");
+#ifdef LINUX
 	fprintf(stderr, "Usage: %s [-v] [-h] [-f] [-r] [-u user] [-t chrootdir] [-d device] "
 			"[-P password] [-6] [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec] "
 			"[-z context] [-F pidfile] [nameserver] topdomain\n", __progname);
+#elif
+	fprintf(stderr, "Usage: %s [-v] [-h] [-f] [-r] [-u user] [-t chrootdir] [-d device] "
+			"[-P password] [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec] "
+			"[-z context] [-F pidfile] [nameserver] topdomain\n", __progname);
+#endif
 	fprintf(stderr, "Options to try if connection doesn't work:\n");
 	fprintf(stderr, "  -T force dns type: NULL, TXT, SRV, MX, CNAME, A (default: autodetect)\n");
 	fprintf(stderr, "  -O force downstream encoding for -T other than NULL: Base32, Base64, Base64u,\n");
@@ -84,7 +97,9 @@ help() {
 	fprintf(stderr, "  -M max size of upstream hostnames (~100-255, default: 255)\n");
 	fprintf(stderr, "  -r to skip raw UDP mode attempt\n");
 	fprintf(stderr, "  -P password used for authentication (max 32 chars will be used)\n");
+#ifdef LINUX
 	fprintf(stderr, "  -6 use IPv6 (make sure to use this option consistently on client and server)\n");
+#endif
 	fprintf(stderr, "Other options:\n");
 	fprintf(stderr, "  -v to print version info and exit\n");
 	fprintf(stderr, "  -h to print this help and exit\n");
@@ -137,7 +152,9 @@ main(int argc, char **argv)
 	int lazymode;
 	int selecttimeout;
 	int hostname_maxlen;
+#ifdef LINUX
 	char v6;
+#endif
 	int rtable = 0;
 
 	nameserv_addr = NULL;
@@ -162,7 +179,9 @@ main(int argc, char **argv)
 	selecttimeout = 4;
 	hostname_maxlen = 0xFF;
 
+#ifdef LINUX
 	v6 = 0;
+#endif
 
 #ifdef WINDOWS32
 	WSAStartup(req_version, &wsa_data);
@@ -179,7 +198,11 @@ main(int argc, char **argv)
 		__progname++;
 #endif
 
+#ifdef LINUX
 	while ((choice = getopt(argc, argv, "6vfhru:t:d:R:P:m:M:F:T:O:L:I:")) != -1) {
+#elif
+	while ((choice = getopt(argc, argv, "vfhru:t:d:R:P:m:M:F:T:O:L:I:")) != -1) {
+#endif
 		switch(choice) {
 		case 'v':
 			version();
@@ -250,9 +273,11 @@ main(int argc, char **argv)
 			if (selecttimeout < 1)
 				selecttimeout = 1;
 			break;
+#ifdef LINUX
 		case '6':
 			v6 = 1;
 			break;
+#endif
 		default:
 			usage();
 			/* NOTREACHED */
@@ -308,7 +333,9 @@ main(int argc, char **argv)
 	client_set_lazymode(lazymode);
 	client_set_topdomain(topdomain);
 	client_set_hostname_maxlen(hostname_maxlen);
+#ifdef LINUX
 	client_set_v6(v6);
+#endif
 	
 	if (username != NULL) {
 #ifndef WINDOWS32

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -65,7 +65,7 @@ usage() {
 	fprintf(stderr, "Usage: %s [-v] [-h] [-f] [-r] [-u user] [-t chrootdir] [-d device] "
 			"[-P password] [-6] [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec] "
 			"[-z context] [-F pidfile] [nameserver] topdomain\n", __progname);
-#elif
+#else
 	fprintf(stderr, "Usage: %s [-v] [-h] [-f] [-r] [-u user] [-t chrootdir] [-d device] "
 			"[-P password] [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec] "
 			"[-z context] [-F pidfile] [nameserver] topdomain\n", __progname);
@@ -82,7 +82,7 @@ help() {
 	fprintf(stderr, "Usage: %s [-v] [-h] [-f] [-r] [-u user] [-t chrootdir] [-d device] "
 			"[-P password] [-6] [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec] "
 			"[-z context] [-F pidfile] [nameserver] topdomain\n", __progname);
-#elif
+#else
 	fprintf(stderr, "Usage: %s [-v] [-h] [-f] [-r] [-u user] [-t chrootdir] [-d device] "
 			"[-P password] [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec] "
 			"[-z context] [-F pidfile] [nameserver] topdomain\n", __progname);
@@ -200,7 +200,7 @@ main(int argc, char **argv)
 
 #ifdef LINUX
 	while ((choice = getopt(argc, argv, "6vfhru:t:d:R:P:m:M:F:T:O:L:I:")) != -1) {
-#elif
+#else
 	while ((choice = getopt(argc, argv, "vfhru:t:d:R:P:m:M:F:T:O:L:I:")) != -1) {
 #endif
 		switch(choice) {

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -315,6 +315,11 @@ main(int argc, char **argv)
 		/* NOTREACHED */
 	}
 
+#ifdef LINUX
+	client_set_v6(v6);
+	client_set_v6_connect(v6_connect);
+#endif
+
 	if (nameserv_addr) {
 		client_set_nameserver(nameserv_addr, DNS_PORT);
 	} else {
@@ -339,10 +344,6 @@ main(int argc, char **argv)
 	client_set_lazymode(lazymode);
 	client_set_topdomain(topdomain);
 	client_set_hostname_maxlen(hostname_maxlen);
-#ifdef LINUX
-	client_set_v6(v6);
-	client_set_v6_connect(v6_connect);
-#endif
 	
 	if (username != NULL) {
 #ifndef WINDOWS32

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -99,7 +99,7 @@ help() {
 	fprintf(stderr, "  -P password used for authentication (max 32 chars will be used)\n");
 #ifdef LINUX
 	fprintf(stderr, "  -6 use IPv6 (make sure to use this option consistently on client and server)\n");
-	fprintf(stderr, "  -7 enable IPv6 outside the tunnel\n");
+	fprintf(stderr, "  -7 enable IPv6 outside the tunnel (currently this option has to be used consistently on client and server)\n");
 #endif
 	fprintf(stderr, "Other options:\n");
 	fprintf(stderr, "  -v to print version info and exit\n");

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -179,7 +179,7 @@ main(int argc, char **argv)
 		__progname++;
 #endif
 
-	while ((choice = getopt(argc, argv, "vfhru6:t:d:R:P:m:M:F:T:O:L:I:")) != -1) {
+	while ((choice = getopt(argc, argv, "6vfhru:t:d:R:P:m:M:F:T:O:L:I:")) != -1) {
 		switch(choice) {
 		case 'v':
 			version();

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -361,7 +361,14 @@ main(int argc, char **argv)
 		goto cleanup1;
 	}
 
-	if ((dns_fd = open_dns(0, INADDR_ANY)) == -1) {
+	/**
+	 * Todo: Fix
+	 */
+//	if ((dns_fd = open_dns(0, INADDR_ANY)) == -1) {
+//		retval = 1;
+//		goto cleanup2;
+//	}
+	if ((dns_fd = open_dns_ipv6(0, in6addr_any)) == -1) {
 		retval = 1;
 		goto cleanup2;
 	}

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -137,9 +137,8 @@ main(int argc, char **argv)
 	int lazymode;
 	int selecttimeout;
 	int hostname_maxlen;
+	char v6;
 	int rtable = 0;
-
-	printf("***MODIFIED***\n");
 
 	nameserv_addr = NULL;
 	topdomain = NULL;
@@ -163,6 +162,8 @@ main(int argc, char **argv)
 	selecttimeout = 4;
 	hostname_maxlen = 0xFF;
 
+	v6 = 0;
+
 #ifdef WINDOWS32
 	WSAStartup(req_version, &wsa_data);
 #endif
@@ -178,7 +179,7 @@ main(int argc, char **argv)
 		__progname++;
 #endif
 
-	while ((choice = getopt(argc, argv, "vfhru:t:d:R:P:m:M:F:T:O:L:I:")) != -1) {
+	while ((choice = getopt(argc, argv, "vfhru6:t:d:R:P:m:M:F:T:O:L:I:")) != -1) {
 		switch(choice) {
 		case 'v':
 			version();
@@ -249,6 +250,9 @@ main(int argc, char **argv)
 			if (selecttimeout < 1)
 				selecttimeout = 1;
 			break;
+		case '6':
+			v6 = 1;
+			break;
 		default:
 			usage();
 			/* NOTREACHED */
@@ -304,6 +308,7 @@ main(int argc, char **argv)
 	client_set_lazymode(lazymode);
 	client_set_topdomain(topdomain);
 	client_set_hostname_maxlen(hostname_maxlen);
+	client_set_v6(v6);
 	
 	if (username != NULL) {
 #ifndef WINDOWS32

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -61,7 +61,7 @@ usage() {
 	extern char *__progname;
 
 	fprintf(stderr, "Usage: %s [-v] [-h] [-f] [-r] [-u user] [-t chrootdir] [-d device] "
-			"[-P password] [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec] "
+			"[-P password] [-6] [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec] "
 			"[-z context] [-F pidfile] [nameserver] topdomain\n", __progname);
 	exit(2);
 }
@@ -72,7 +72,7 @@ help() {
 
 	fprintf(stderr, "iodine IP over DNS tunneling client\n");
 	fprintf(stderr, "Usage: %s [-v] [-h] [-f] [-r] [-u user] [-t chrootdir] [-d device] "
-			"[-P password] [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec] "
+			"[-P password] [-6] [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec] "
 			"[-z context] [-F pidfile] [nameserver] topdomain\n", __progname);
 	fprintf(stderr, "Options to try if connection doesn't work:\n");
 	fprintf(stderr, "  -T force dns type: NULL, TXT, SRV, MX, CNAME, A (default: autodetect)\n");
@@ -84,6 +84,7 @@ help() {
 	fprintf(stderr, "  -M max size of upstream hostnames (~100-255, default: 255)\n");
 	fprintf(stderr, "  -r to skip raw UDP mode attempt\n");
 	fprintf(stderr, "  -P password used for authentication (max 32 chars will be used)\n");
+	fprintf(stderr, "  -6 use IPv6 (make sure to use this option consistently on client and server)\n");
 	fprintf(stderr, "Other options:\n");
 	fprintf(stderr, "  -v to print version info and exit\n");
 	fprintf(stderr, "  -h to print this help and exit\n");
@@ -139,7 +140,6 @@ main(int argc, char **argv)
 	int rtable = 0;
 
 	printf("***MODIFIED***\n");
-	fflush(stdout);
 
 	nameserv_addr = NULL;
 	topdomain = NULL;

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -369,11 +369,6 @@ main(int argc, char **argv)
 		goto cleanup1;
 	}
 
-
-//	if ((dns_fd = open_dns(0, INADDR_ANY)) == -1) {
-//		retval = 1;
-//		goto cleanup2;
-//	}
 #ifdef LINUX
 	if ((dns_fd = v6_connect ? open_dns_ipv6(0, in6addr_any) : open_dns(0, INADDR_ANY)) == -1) {
 #else

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2023,6 +2023,8 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 			q->fromlen = addrlen;
 		}
 
+		ipv6_print(&(from6.sin6_addr), 42);
+
 		/* TODO do not handle raw packets here! */
 		if (raw_decode(packet, r, q, fd, tun_fd)) {
 			return 0;

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -154,6 +154,12 @@ check_user_and_ip(int userid, struct query *q)
 		return 0;
 	}
 
+	/**
+	 * Todo: IPv6
+	 */
+
+	return 0;
+
 	tempin = (struct sockaddr_in *) &(q->from);
 	return memcmp(&(users[userid].host), &(tempin->sin_addr), sizeof(struct in_addr));
 }
@@ -886,7 +892,7 @@ handle_null_request(int tun_fd, int dns_fd, struct query *q, int domain_len)
 				return; /* illegal id */
 			}
 
-			if (memcmp(&ns_ip6, &in6addr_any, sizeof(struct in6_addr))) {
+			if (0 && memcmp(&ns_ip6, &in6addr_any, sizeof(struct in6_addr))) {
 				/* If set, use assigned external ip (-n option) */
 				memcpy(&replyaddr, &ns_ip6, sizeof(struct in6_addr));
 			} else {
@@ -897,6 +903,10 @@ handle_null_request(int tun_fd, int dns_fd, struct query *q, int domain_len)
 			reply[0] = 'I';
 			for(i = 0; i < sizeof(struct in6_addr); i++)
 				reply[i + 1] = replyaddr.__in6_u.__u6_addr8[i];
+
+			printf("tuuuut:\n");
+			ipv6_print((void*)reply + 1, 0);
+
 			write_dns(dns_fd, q, reply, sizeof(reply), 'T');
 		} else {
 #endif
@@ -1524,7 +1534,7 @@ handle_ns_request(int dns_fd, struct query *q)
 
 #ifdef LINUX
 	if (v6_listen) {
-		if(memcmp(&ns_ip6, &in6addr_any, sizeof(struct in6_addr)))
+		if(0 && memcmp(&ns_ip6, &in6addr_any, sizeof(struct in6_addr)))
 			memcpy(&q->destination.v6, &ns_ip6, sizeof(struct in6_addr));
 	} else
 #endif
@@ -1562,7 +1572,7 @@ handle_a_request(int dns_fd, struct query *q, int fakeip)
 	if (v6_listen) {
 		if (fakeip)
 			memcpy(&q->destination.v6, &in6addr_loopback, sizeof(in_addr_t));
-		else if (memcmp(&ns_ip6, &in6addr_any, sizeof(struct in6_addr))) {
+		else if (0 && memcmp(&ns_ip6, &in6addr_any, sizeof(struct in6_addr))) {
 			/* If ns_ip set, overwrite destination addr with it.
 			 * Destination addr will be sent as additional record (A, IN) */
 			memcpy(&q->destination.v4.s_addr, &ns_ip6, sizeof(struct in6_addr));
@@ -2096,6 +2106,8 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 		}
 
 #ifndef WINDOWS32
+		memcpy(&q->destination.v6, &in6addr_loopback, sizeof(struct in6_addr));
+
 		for (cmsg = CMSG_FIRSTHDR(&msg); cmsg != NULL;
 			cmsg = CMSG_NXTHDR(&msg, cmsg)) {
 

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -88,6 +88,8 @@ static in_addr_t ns_ip;
 static int bind_port;
 static int debug;
 
+static char v6;
+
 #if !defined(BSD) && !defined(__GLIBC__)
 static char *__progname;
 #endif
@@ -801,21 +803,27 @@ handle_null_request(int tun_fd, int dns_fd, struct query *q, int domain_len)
 				tempip.s_addr = users[userid].tun_ip;
 				tmp[1] = strdup(inet_ntoa(tempip));
 
-				struct in6_addr ip6;
+				if (v6) {
+					struct in6_addr ip6;
 
-				memcpy(&ip6, &my_net6, sizeof(my_net6));
-				ipv6_addr_add(&ip6, 1);
-				char server6[41];
-				inet_ntop(AF_INET6, &ip6, server6, sizeof(server6));
+					memcpy(&ip6, &my_net6, sizeof(my_net6));
+					ipv6_addr_add(&ip6, 1);
+					char server6[41];
+					inet_ntop(AF_INET6, &ip6, server6, sizeof(server6));
 
-				memcpy(&ip6, &(users[userid].tun_ip6), sizeof(my_net6));
-				char client6[41];
-				inet_ntop(AF_INET6, &ip6, client6, sizeof(client6));
+					memcpy(&ip6, &(users[userid].tun_ip6), sizeof(my_net6));
+					char client6[41];
+					inet_ntop(AF_INET6, &ip6, client6, sizeof(client6));
 
-				read = snprintf(out, sizeof(out), "%s-%s-%d-%d-%s-%s-%d",
-						tmp[0], tmp[1], my_mtu, netmask, server6, client6, netmask6);
+					read = snprintf(out, sizeof(out), "%s-%s-%d-%d-%s-%s-%d",
+							tmp[0], tmp[1], my_mtu, netmask, server6, client6,
+							netmask6);
+				}
 
-				printf("%s\n", out);
+				read = snprintf(out, sizeof(out), "%s-%s-%d-%d",
+						tmp[0], tmp[1], my_mtu, netmask);
+
+				//printf("%s\n", out);
 
 				write_dns(dns_fd, q, out, read, users[userid].downenc);
 				q->id = 0;
@@ -2245,8 +2253,6 @@ main(int argc, char **argv)
 	int skipipconfig;
 	char *netsize;
 	int retval;
-
-	char v6;
 
 #ifndef WINDOWS32
 	pw = NULL;

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2289,6 +2289,9 @@ main(int argc, char **argv)
 	int dnsd_fd;
 	int tun_fd;
 
+	int v6_listen;
+
+
 	/* settings for forwarding normal DNS to 
 	 * local real DNS server */
 	int bind_fd;
@@ -2324,6 +2327,7 @@ main(int argc, char **argv)
 	pidfile = NULL;
 #ifdef LINUX
 	v6 = 0;
+	v6_listen = 1;
 #endif
 
 	b32 = get_base32_encoder();
@@ -2592,10 +2596,13 @@ main(int argc, char **argv)
 #endif
 		free((void*) other_ip);
 	}
-	if ((dnsd_fd = open_dns(port, listen_ip)) == -1) {
+	if ((dnsd_fd = v6_listen ? open_dns_ipv6(port, in6addr_any) : open_dns(port, listen_ip)) == -1) {
 		retval = 1;
 		goto cleanup2;
 	}
+	/**
+	 * Todo: IPv6?
+	 */
 	if (bind_enable) {
 		if ((bind_fd = open_dns(0, INADDR_ANY)) == -1) {
 			retval = 1;

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2106,7 +2106,8 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 		}
 
 #ifndef WINDOWS32
-		memcpy(&q->destination.v6, &in6addr_loopback, sizeof(struct in6_addr));
+		//memcpy(&q->destination.v6, &in6addr_loopback, sizeof(struct in6_addr));
+		inet_pton(AF_INET6, "2001:4ca0:2001:18:216:3eff:fe99:4d2b", &q->destination.v6);
 
 		for (cmsg = CMSG_FIRSTHDR(&msg); cmsg != NULL;
 			cmsg = CMSG_NXTHDR(&msg, cmsg)) {

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2382,7 +2382,7 @@ help() {
 	fprintf(stderr, "     (using -DD in UTF-8 terminal: \"LC_ALL=C luit iodined -DD ...\")\n");
 #ifdef LINUX
 	fprintf(stderr, "  -6 use IPv6 inside the tunnel (make sure to use this option consistently on client and server)\n");
-	fprintf(stderr, "  -7 enable IPv6 outside the tunnel\n");
+	fprintf(stderr, "  -7 enable IPv6 outside the tunnel (currently this option has to be used consistently on client and server)\n");
 #endif
 	fprintf(stderr, "  -u name to drop privileges and run as user 'name'\n");
 	fprintf(stderr, "  -t dir to chroot to directory dir\n");

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2077,9 +2077,6 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 
 	r = recvmsg(fd, &msg, 0);
 
-	printf("Elende Zicke\n");
-	ipv6_print(msg.msg_control, 00);
-
 	printf("[DEBUG] read_dns() - Received message...\n");
 
 #else

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -818,10 +818,9 @@ handle_null_request(int tun_fd, int dns_fd, struct query *q, int domain_len)
 					read = snprintf(out, sizeof(out), "%s-%s-%d-%d-%s-%s-%d",
 							tmp[0], tmp[1], my_mtu, netmask, server6, client6,
 							netmask6);
-				}
-
-				read = snprintf(out, sizeof(out), "%s-%s-%d-%d",
-						tmp[0], tmp[1], my_mtu, netmask);
+				} else
+					read = snprintf(out, sizeof(out), "%s-%s-%d-%d", tmp[0],
+							tmp[1], my_mtu, netmask);
 
 				//printf("%s\n", out);
 
@@ -2299,7 +2298,7 @@ main(int argc, char **argv)
 	srand(time(NULL));
 	fw_query_init();
 
-	while ((choice = getopt(argc, argv, "vcsfhD6u:t:d:m:l:p:n:b:P:z:F:")) != -1) {
+	while ((choice = getopt(argc, argv, "6vcsfhDu:t:d:m:l:p:n:b:P:z:F:")) != -1) {
 		switch(choice) {
 		case 'v':
 			version();
@@ -2371,7 +2370,7 @@ main(int argc, char **argv)
 
 	check_superuser(usage);
 
-	if (argc != 3)
+	if (argc != 2 + v6)
 		usage();
 
 	netsize = strchr(argv[0], '/');

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2365,7 +2365,7 @@ main(int argc, char **argv)
 
 	check_superuser(usage);
 
-	if (argc != 2)
+	if (argc != 3)
 		usage();
 
 	netsize = strchr(argv[0], '/');

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2124,9 +2124,12 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 				//	ipv6_print(&q->from.v6, 44);
 			}
 			if (cmsg->cmsg_level == IPPROTO_IPV6 &&
-				cmsg->cmsg_type == DSTADDR_SOCKOPT) {
+				cmsg->cmsg_type == IPV6_PKTINFO) {
 
 				memcpy(&q->destination.v6, cmsg->__cmsg_data, sizeof(struct in6_addr));
+
+				printf("hallo\n");
+				ipv6_print(&q->destination.v6, 0);
 
 				break;//	printf("write_dns()\n");
 				//	ipv6_print(&q->from.v6, 44);

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2197,7 +2197,7 @@ usage() {
 		"[-l ip address to listen on] [-p port] [-n external ip] "
 		"[-b dnsport] [-P password] [-F pidfile] "
 		"tunnel_ip[/netmask] [tunnel_net6/netmask6] topdomain\n", __progname);
-#elif
+#else
 	fprintf(stderr, "Usage: %s [-v] [-h] [-c] [-s] [-f] [-D] [-u user] "
 		"[-t chrootdir] [-d device] [-m mtu] [-z context] "
 		"[-l ip address to listen on] [-p port] [-n external ip] "
@@ -2217,7 +2217,7 @@ help() {
 		"[-t chrootdir] [-d device] [-m mtu] [-z context] "
 		"[-l ip address to listen on] [-p port] [-n external ip] [-b dnsport] [-P password] "
 		"[-F pidfile] tunnel_ip[/netmask] [tunnel_net6/netmask6] topdomain\n", __progname);
-#elif
+#else
 	fprintf(stderr, "Usage: %s [-v] [-h] [-c] [-s] [-f] [-D] [-u user] "
 		"[-t chrootdir] [-d device] [-m mtu] [-z context] "
 		"[-l ip address to listen on] [-p port] [-n external ip] [-b dnsport] [-P password] "
@@ -2342,7 +2342,7 @@ main(int argc, char **argv)
 
 #ifdef LINUX
 	while ((choice = getopt(argc, argv, "6vcsfhDu:t:d:m:l:p:n:b:P:z:F:")) != -1) {
-#elif
+#else
 	while ((choice = getopt(argc, argv, "vcsfhDu:t:d:m:l:p:n:b:P:z:F:")) != -1) {
 #endif
 		switch(choice) {
@@ -2420,7 +2420,7 @@ main(int argc, char **argv)
 
 #ifdef LINUX
 	if (argc != 2 + v6)
-#elif
+#else
 	if (argc != 2)
 #endif
 		usage();
@@ -2471,7 +2471,7 @@ main(int argc, char **argv)
 
 #ifdef LINUX
 	topdomain = strdup(argv[1 + v6]);
-#elif
+#else
 	topdomain = strdup(argv[1]);
 #endif
 	if (strlen(topdomain) <= 128) {

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -726,7 +726,11 @@ handle_null_request(int tun_fd, int dns_fd, struct query *q, int domain_len)
 					   ((unpacked[3] & 0xff)));
 		}
 
+#ifdef LINUX
+		if (version == v6 ? VERSION_V6 : VERSION) {
+#else
 		if (version == VERSION) {
+#endif
 			userid = find_available_user();
 			if (userid >= 0) {
 				int i;
@@ -787,7 +791,12 @@ handle_null_request(int tun_fd, int dns_fd, struct query *q, int domain_len)
 					inet_ntoa(((struct sockaddr_in *) &q->from)->sin_addr));
 			}
 		} else {
-			send_version_response(dns_fd, VERSION_NACK, VERSION, 0, q);
+#ifdef LINUX
+			if (v6)
+				send_version_response(dns_fd, VERSION_NACK, VERSION_V6, 0, q);
+			else
+#endif
+				send_version_response(dns_fd, VERSION_NACK, VERSION, 0, q);
 			syslog(LOG_INFO, "dropped user from %s, sent bad version %08X",
 				inet_ntoa(((struct sockaddr_in *) &q->from)->sin_addr), version);
 		}

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2468,6 +2468,9 @@ main(int argc, char **argv)
 #endif
 	port = 53;
 	ns_ip = INADDR_ANY;
+#ifdef LINUX
+	memcpy(&ns_ip6, &in6addr_any, sizeof(in6addr_any));
+#endif
 	check_ip = 1;
 	skipipconfig = 0;
 	debug = 0;

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2406,6 +2406,11 @@ main(int argc, char **argv)
 			usage();
 		}
 
+		if(mtu < 1280) {
+			fprintf(stderr, "Increasing MTU from %u to 1280 (as needed by IPv6)\n", mtu);
+			mtu = 1280;
+		}
+
 		fprintf(stderr, "IPv6 network: ");
 		ipv6_print(&my_net6, netmask6);
 	}

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -1654,10 +1654,8 @@ tunnel_dns(int tun_fd, int dns_fd, int bind_fd)
 	if (domain_len >= 1 && q.name[domain_len - 1] != '.')
 		inside_topdomain = 0;
 
-	/**
-	 * Todo: Fix v6
-	 */
-	if (inside_topdomain || 1) {
+
+	if (inside_topdomain) {
 		/* This is a query we can handle */
 
 		/* Handle A-type query for ns.topdomain, possibly caused

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2116,6 +2116,8 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 			cmsg = CMSG_NXTHDR(&msg, cmsg)) {
 
 			printf("cmsg != NULL!\n");
+			printf("Vaavvaaaa\n");
+			ipv6_print(cmsg->__cmsg_data, 00);
 
 			if (cmsg->cmsg_level == IPPROTO_IP &&
 				cmsg->cmsg_type == DSTADDR_SOCKOPT) {
@@ -2132,9 +2134,6 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 				break;//	printf("write_dns()\n");
 				//	ipv6_print(&q->from.v6, 44);
 			}
-
-			printf("Vaavvaaaa\n");
-			ipv6_print(cmsg->__cmsg_data, 00);
 		}
 #endif
 		return strlen(q->name);

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -89,6 +89,9 @@ static int netmask;
 static char netmask6;
 
 static in_addr_t ns_ip;
+#ifdef LINUX
+static struct in6_addr ns_ip6;
+#endif
 
 static int bind_port;
 static int debug;
@@ -2049,7 +2052,8 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 				cmsg->cmsg_type == DSTADDR_SOCKOPT) {
 
 				q->destination = *dstaddr(cmsg);
-				break;
+				break;//	printf("write_dns()\n");
+				//	ipv6_print(&q->from.v6, 44);
 			}
 		}
 #endif
@@ -2219,10 +2223,10 @@ write_dns(int fd, struct query *q, char *data, int datalen, char downenc)
 			inet_ntoa(tempin->sin_addr), q->type, q->name, datalen);
 	}
 
-	printf("write_dns()\n");
-	ipv6_print(&q->from.v6, 44);
+//	printf("write_dns()\n");
+//	ipv6_print(&q->from.v6, 44);
 
-	sendto(fd, buf, len, 0, (struct sockaddr*)&(q->from.v6), q->fromlen);
+	sendto(fd, buf, len, 0, (struct sockaddr*)&q->from, q->fromlen);
 }
 
 static void
@@ -2352,7 +2356,9 @@ main(int argc, char **argv)
 	mtu = 1130;	/* Very many relays give fragsize 1150 or slightly
 			   higher for NULL; tun/zlib adds ~17 bytes. */
 	listen_ip = INADDR_ANY;
+#ifdef LINUX
 	listen_ip6 = in6addr_any;
+#endif
 	port = 53;
 	ns_ip = INADDR_ANY;
 	check_ip = 1;

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2405,7 +2405,7 @@ main(int argc, char **argv)
 		ipv6_print(&my_net6, netmask6);
 	}
 
-	topdomain = strdup(argv[1]);
+	topdomain = strdup(argv[2]);
 	if (strlen(topdomain) <= 128) {
 		if(check_topdomain(topdomain)) {
 			warnx("Topdomain contains invalid characters.");

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2077,6 +2077,9 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 
 	r = recvmsg(fd, &msg, 0);
 
+	printf("Elende Zicke\n");
+	ipv6_print(msg.msg_control, 00);
+
 	printf("[DEBUG] read_dns() - Received message...\n");
 
 #else
@@ -2126,12 +2129,12 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 
 				memcpy(&q->destination.v6, cmsg->__cmsg_data, sizeof(struct in6_addr));
 
-				printf("Vaavvaaaa\n");
-				ipv6_print(&q->destination.v6, 00);
-
 				break;//	printf("write_dns()\n");
 				//	ipv6_print(&q->from.v6, 44);
 			}
+
+			printf("Vaavvaaaa\n");
+			ipv6_print(cmsg->__cmsg_data, 00);
 		}
 #endif
 		return strlen(q->name);

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2220,8 +2220,8 @@ write_dns(int fd, struct query *q, char *data, int datalen, char downenc)
 			inet_ntoa(tempin->sin_addr), q->type, q->name, datalen);
 	}
 
-//	printf("write_dns()");
-//	ipv6_print(&q->from.v6)
+	printf("write_dns()\n");
+	ipv6_print(&q->from.v6.sin6_addr, 44);
 
 	sendto(fd, buf, len, 0, (struct sockaddr*)&(q->from.v6), q->fromlen);
 }

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -561,7 +561,7 @@ tunnel_tun(int tun_fd, int dns_fd)
 		return 0;
 
 	uint16_t *header_info = (uint16_t*)in;
-	if(ntohs(header_info[1]) == 0x0008) {
+	if(header_info[1] == 0x0008) {
 		/* find target ip in packet, in is padded with 4 bytes TUN header */
 		header = (struct ip*) (in + 4);
 		userid = find_user_by_ip(header->ip_dst.s_addr);
@@ -577,7 +577,7 @@ tunnel_tun(int tun_fd, int dns_fd)
 		printf("%04x%s", ntohs((header6->ip6_dst).__in6_u.__u6_addr16[i]), i < 7 ? ":"
 				: "\n");
 
-	printf("tunnel_tun() - userid = %d, ntohs(header_info[1]) = %d\n", userid, ntohs(header_info[1]));
+	printf("tunnel_tun() - userid = %d, header_info[1] = %d\n", userid, header_info[1]);
 
 	if (userid < 0)
 		return 0;

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -571,11 +571,11 @@ tunnel_tun(int tun_fd, int dns_fd)
 		userid = find_user_by_ip6(header6->ip6_dst);
 	}
 
-	printf("header6->ip6_dst: ");
-	char i;
-	for (i = 0; i < 8; ++i)
-		printf("%04x%s", ntohs((header6->ip6_dst).__in6_u.__u6_addr16[i]), i < 7 ? ":"
-				: "\n");
+//	printf("header6->ip6_dst: ");
+//	char i;
+//	for (i = 0; i < 8; ++i)
+//		printf("%04x%s", ntohs((header6->ip6_dst).__in6_u.__u6_addr16[i]), i < 7 ? ":"
+//				: "\n");
 
 	printf("tunnel_tun() - userid = %d, header_info[1] = %d\n", userid, header_info[1]);
 

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2410,7 +2410,7 @@ main(int argc, char **argv)
 		ipv6_print(&my_net6, netmask6);
 	}
 
-	topdomain = strdup(argv[2]);
+	topdomain = strdup(argv[1 + v6]);
 	if (strlen(topdomain) <= 128) {
 		if(check_topdomain(topdomain)) {
 			warnx("Topdomain contains invalid characters.");

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -727,7 +727,7 @@ handle_null_request(int tun_fd, int dns_fd, struct query *q, int domain_len)
 		}
 
 #ifdef LINUX
-		if (version == v6 ? VERSION_V6 : VERSION) {
+		if (version == (v6 ? VERSION_V6 : VERSION)) {
 #else
 		if (version == VERSION) {
 #endif

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -1638,6 +1638,8 @@ tunnel_dns(int tun_fd, int dns_fd, int bind_fd)
 	if ((read = read_dns(dns_fd, tun_fd, &q)) <= 0)
 		return 0;
 
+	printf("DEBUG - 0\n");
+
 	if (debug >= 2) {
 		struct sockaddr_in *tempin;
 		tempin = (struct sockaddr_in *) &(q.from);
@@ -1652,7 +1654,10 @@ tunnel_dns(int tun_fd, int dns_fd, int bind_fd)
 	if (domain_len >= 1 && q.name[domain_len - 1] != '.')
 		inside_topdomain = 0;
 
-	if (inside_topdomain) {
+	/**
+	 * Todo: Fix v6
+	 */
+	if (inside_topdomain || 1) {
 		/* This is a query we can handle */
 
 		/* Handle A-type query for ns.topdomain, possibly caused

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2124,7 +2124,11 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 			if (cmsg->cmsg_level == IPPROTO_IPV6 &&
 				cmsg->cmsg_type == DSTADDR_SOCKOPT) {
 
-				memcpy(&q->destination.v6, dstaddr(cmsg), sizeof(struct in6_addr));
+				memcpy(&q->destination.v6, cmsg->__cmsg_data, sizeof(struct in6_addr));
+
+				printf("Vaavvaaaa\n");
+				ipv6_print(&q->destination.v6, 00);
+
 				break;//	printf("write_dns()\n");
 				//	ipv6_print(&q->from.v6, 44);
 			}

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -191,13 +191,10 @@ send_raw(int fd, char *buf, int buflen, int user, int cmd, struct query *q)
 			inet_ntoa(tempin->sin_addr), cmd, len);
 	}
 
-//	printf("send_raw()");
-//	ipv6_print(&q->from.v6.sin6_addr, 66);
-
 	if(v6_listen)
-		sendto(fd, packet, len, 0, &q->from.v6, q->fromlen);
+		sendto(fd, packet, len, 0, (struct sockaddr *)&q->from.v6, q->fromlen);
 	else
-		sendto(fd, packet, len, 0, &q->from.v4, q->fromlen);
+		sendto(fd, packet, len, 0, (struct sockaddr *)&q->from.v4, q->fromlen);
 }
 
 static void
@@ -2112,7 +2109,7 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 
 	r = recvmsg(fd, &msg, 0);
 
-//	printf("[DEBUG] read_dns() - Received message...\n");
+/*	printf("[DEBUG] read_dns() - Received message...\n"); */
 
 #else
 	addrlen = sizeof(struct sockaddr);
@@ -2149,8 +2146,7 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 				cmsg->cmsg_type == DSTADDR_SOCKOPT) {
 
 				q->destination.v4 = *dstaddr(cmsg);
-				break;//	printf("write_dns()\n");
-				//	ipv6_print(&q->from.v6, 44);
+				break;
 			}
 #ifdef LINUX
 			if (cmsg->cmsg_level == IPPROTO_IPV6 &&
@@ -2158,8 +2154,7 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 
 				memcpy(&q->destination.v6, cmsg->__cmsg_data, sizeof(struct in6_addr));
 
-				break;//	printf("write_dns()\n");
-				//	ipv6_print(&q->from.v6, 44);
+				break;
 			}
 #endif
 		}
@@ -2329,9 +2324,6 @@ write_dns(int fd, struct query *q, char *data, int datalen, char downenc)
 		fprintf(stderr, "TX: client %s, type %d, name %s, %d bytes data\n",
 			inet_ntoa(tempin->sin_addr), q->type, q->name, datalen);
 	}
-
-//	printf("write_dns()\n");
-//	ipv6_print(&q->from.v6, 44);
 
 	sendto(fd, buf, len, 0, (struct sockaddr*)&q->from, q->fromlen);
 }

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -1997,6 +1997,9 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 	msg.msg_flags = 0;
 
 	r = recvmsg(fd, &msg, 0);
+
+	printf("[DEBUG] read_dns() - Received message...\n");
+
 #else
 	addrlen = sizeof(struct sockaddr);
 	r = recvfrom(fd, packet, sizeof(packet), 0, (struct sockaddr*)&from, &addrlen);

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -178,7 +178,13 @@ send_raw(int fd, char *buf, int buflen, int user, int cmd, struct query *q)
 			inet_ntoa(tempin->sin_addr), cmd, len);
 	}
 
-	sendto(fd, packet, len, 0, &q->from, q->fromlen);
+	printf("send_raw()");
+	ipv6_print(&q->from.v6.sin6_addr, 66);
+
+	if(v6_listen)
+		sendto(fd, packet, len, 0, &q->from.v6, q->fromlen);
+	else
+		sendto(fd, packet, len, 0, &q->from.v4, q->fromlen);
 }
 
 

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -154,14 +154,18 @@ check_user_and_ip(int userid, struct query *q)
 		return 0;
 	}
 
-	/**
-	 * Todo: IPv6
-	 */
-
-	return 0;
-
-	tempin = (struct sockaddr_in *) &(q->from);
-	return memcmp(&(users[userid].host), &(tempin->sin_addr), sizeof(struct in_addr));
+#ifdef LINUX
+	if (v6_listen) {
+		return memcmp(&(users[userid].host.v6), &q->from.v6,
+				sizeof(struct in6_addr));
+	} else {
+#endif
+		tempin = (struct sockaddr_in *) &(q->from);
+		return memcmp(&(users[userid].host), &(tempin->sin_addr),
+				sizeof(struct in_addr));
+#ifdef LINUX
+	}
+#endif
 }
 
 static void

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -1728,8 +1728,6 @@ tunnel_dns(int tun_fd, int dns_fd, int bind_fd)
 	if ((read = read_dns(dns_fd, tun_fd, &q)) <= 0)
 		return 0;
 
-	printf("DEBUG - 0\n");
-
 	if (debug >= 2) {
 		struct sockaddr_in *tempin;
 		tempin = (struct sockaddr_in *) &(q.from);
@@ -2114,7 +2112,7 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 
 	r = recvmsg(fd, &msg, 0);
 
-	printf("[DEBUG] read_dns() - Received message...\n");
+//	printf("[DEBUG] read_dns() - Received message...\n");
 
 #else
 	addrlen = sizeof(struct sockaddr);
@@ -2135,9 +2133,6 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 #ifdef LINUX
 		}
 #endif
-
-		ipv6_print(&(from6.sin6_addr), 42);
-
 		/* TODO do not handle raw packets here! */
 		if (raw_decode(packet, r, q, fd, tun_fd)) {
 			return 0;

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2023,11 +2023,11 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 
 	if (r > 0) {
 		if (v6_listen) {
-			memcpy((struct sockaddr*) &q->from, (struct sockaddr*) &from6,
+			memcpy(&q->from.v6, &from6,
 					sizeof(struct sockaddr_in6));
 			q->fromlen = sizeof(struct sockaddr_in6);
 		} else {
-			memcpy((struct sockaddr*) &q->from, (struct sockaddr*) &from,
+			memcpy((struct sockaddr*) &q->from.v4, (struct sockaddr*) &from,
 					addrlen);
 			q->fromlen = addrlen;
 		}
@@ -2223,7 +2223,7 @@ write_dns(int fd, struct query *q, char *data, int datalen, char downenc)
 	printf("write_dns()\n");
 	ipv6_print(&q->from.v6.sin6_addr, 44);
 
-	sendto(fd, buf, len, 0, (struct sockaddr*)&(q->from.v6), q->fromlen);
+	sendto(fd, buf, len, 0, (struct sockaddr*)&q->from, q->fromlen);
 }
 
 static void

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2220,7 +2220,10 @@ write_dns(int fd, struct query *q, char *data, int datalen, char downenc)
 			inet_ntoa(tempin->sin_addr), q->type, q->name, datalen);
 	}
 
-	sendto(fd, buf, len, 0, (struct sockaddr*)&q->from, q->fromlen);
+//	printf("write_dns()");
+//	ipv6_print(&q->from.v6)
+
+	sendto(fd, buf, len, 0, (struct sockaddr*)&(q->from.v6), q->fromlen);
 }
 
 static void

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2023,11 +2023,11 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 
 	if (r > 0) {
 		if (v6_listen) {
-			memcpy(&q->from.v6, &from6,
+			memcpy((struct sockaddr*) &q->from, (struct sockaddr*) &from6,
 					sizeof(struct sockaddr_in6));
 			q->fromlen = sizeof(struct sockaddr_in6);
 		} else {
-			memcpy((struct sockaddr*) &q->from.v4, (struct sockaddr*) &from,
+			memcpy((struct sockaddr*) &q->from, (struct sockaddr*) &from,
 					addrlen);
 			q->fromlen = addrlen;
 		}
@@ -2221,9 +2221,9 @@ write_dns(int fd, struct query *q, char *data, int datalen, char downenc)
 	}
 
 	printf("write_dns()\n");
-	ipv6_print(&q->from.v6.sin6_addr, 44);
+	ipv6_print(&q->from.v6, 44);
 
-	sendto(fd, buf, len, 0, (struct sockaddr*)&q->from, q->fromlen);
+	sendto(fd, buf, len, 0, (struct sockaddr*)&(q->from.v6), q->fromlen);
 }
 
 static void

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2107,10 +2107,12 @@ read_dns(int fd, int tun_fd, struct query *q) /* FIXME: tun_fd is because of raw
 
 #ifndef WINDOWS32
 		//memcpy(&q->destination.v6, &in6addr_loopback, sizeof(struct in6_addr));
-		inet_pton(AF_INET6, "2001:4ca0:2001:18:216:3eff:fe99:4d2b", &q->destination.v6);
+		//inet_pton(AF_INET6, "2001:4ca0:2001:18:216:3eff:fe99:4d2b", &q->destination.v6);
 
 		for (cmsg = CMSG_FIRSTHDR(&msg); cmsg != NULL;
 			cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+
+			printf("cmsg != NULL!\n");
 
 			if (cmsg->cmsg_level == IPPROTO_IP &&
 				cmsg->cmsg_type == DSTADDR_SOCKOPT) {

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -571,13 +571,7 @@ tunnel_tun(int tun_fd, int dns_fd)
 		userid = find_user_by_ip6(header6->ip6_dst);
 	}
 
-//	printf("header6->ip6_dst: ");
-//	char i;
-//	for (i = 0; i < 8; ++i)
-//		printf("%04x%s", ntohs((header6->ip6_dst).__in6_u.__u6_addr16[i]), i < 7 ? ":"
-//				: "\n");
-
-	printf("tunnel_tun() - userid = %d, header_info[1] = %d\n", userid, header_info[1]);
+//	printf("tunnel_tun() - userid = %d, header_info[1] = %d\n", userid, header_info[1]);
 
 	if (userid < 0)
 		return 0;
@@ -2369,10 +2363,7 @@ main(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 
-	/*
-	 * Todo: Uncomment
-	 */
-//	check_superuser(usage);
+	check_superuser(usage);
 
 	if (argc != 2)
 		usage();

--- a/src/tun.c
+++ b/src/tun.c
@@ -550,14 +550,6 @@ tun_setmtu(unsigned mtu)
 #ifndef WINDOWS32
 	char cmdline[512];
 
-	/**
-	 * Todo: Correct?
-	 */
-	if(mtu < 1280) {
-		fprintf(stderr, "Increasing MTU from %u to 1280 (as needed by IPv6)\n", mtu);
-		mtu = 1280;
-	}
-
 	if (mtu > 200 && mtu <= 1500) {
 		snprintf(cmdline, sizeof(cmdline), 
 				IFCONFIGPATH "ifconfig %s mtu %u",

--- a/src/tun.c
+++ b/src/tun.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2006-2009 Bjorn Andersson <flex@kryo.se>, Erik Ekman <yarrick@kryo.se>
+ * Copyright (c) 2011-2012 Julian Kranz <julian@juliankranz.de>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -441,6 +442,7 @@ read_tun(int tun_fd, char *buf, size_t len)
 #endif /* !FREEBSD */
 }
 
+#ifdef LINUX
 int tun_setip6(char const *ip6, char netmask6) {
 	char cmdline[512];
 
@@ -454,6 +456,7 @@ int tun_setip6(char const *ip6, char netmask6) {
 
 	return system(cmdline);
 }
+#endif
 
 int
 tun_setip(const char *ip, const char *other_ip, int netbits)

--- a/src/tun.c
+++ b/src/tun.c
@@ -365,7 +365,7 @@ close_tun(int tun_fd)
 int 
 write_tun(int tun_fd, unsigned char *data, size_t len, char version)
 {
-	printf("write_tun() - version = %d\n", version);
+	/* printf("write_tun() - version = %d\n", version); */
 #if defined (FREEBSD) || defined (DARWIN) || defined(NETBSD) || defined(WINDOWS32)
 	data += 4;
 	len -= 4;

--- a/src/tun.h
+++ b/src/tun.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2006-2009 Bjorn Andersson <flex@kryo.se>, Erik Ekman <yarrick@kryo.se>
+ * Copyright (c) 2011-2012 Julian Kranz <julian@juliankranz.de>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -22,7 +23,9 @@ void close_tun(int);
 int write_tun(int, unsigned char *, size_t, char version);
 ssize_t read_tun(int, char *, size_t);
 int tun_setip(const char *, const char *, int);
+#ifdef LINUX
 int tun_setip6(char const *ip6, char netmask6);
+#endif
 int tun_setmtu(unsigned);
 
 #endif /* _TUN_H_ */

--- a/src/user.c
+++ b/src/user.c
@@ -40,7 +40,7 @@ unsigned usercount;
 int
 #ifdef LINUX
 init_users(in_addr_t my_ip, int netbits, struct in6_addr my_net6)
-#elif
+#else
 init_users(in_addr_t my_ip, int netbits)
 #endif
 {

--- a/src/user.c
+++ b/src/user.c
@@ -121,8 +121,6 @@ find_user_by_ip(uint32_t ip)
 	int ret;
 	int i;
 
-	return 0;
-
 	ret = -1;
 	for (i = 0; i < usercount; i++) {
 		if (users[i].active && !users[i].disabled &&

--- a/src/user.c
+++ b/src/user.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2006-2009 Bjorn Andersson <flex@kryo.se>, Erik Ekman <yarrick@kryo.se>
+ * Copyright (c) 2011-2012 Julian Kranz <julian@juliankranz.de>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -133,6 +134,7 @@ find_user_by_ip(uint32_t ip)
 	return ret;
 }
 
+#ifdef LINUX
 int
 find_user_by_ip6(struct in6_addr ip)
 {
@@ -150,6 +152,7 @@ find_user_by_ip6(struct in6_addr ip)
 	}
 	return ret;
 }
+#endif
 
 int
 all_users_waiting_to_send()

--- a/src/user.c
+++ b/src/user.c
@@ -38,7 +38,11 @@ struct user *users;
 unsigned usercount;
 
 int
+#ifdef LINUX
 init_users(in_addr_t my_ip, int netbits, struct in6_addr my_net6)
+#elif
+init_users(in_addr_t my_ip, int netbits)
+#endif
 {
 	int i;
 	int skip = 0;
@@ -50,9 +54,11 @@ init_users(in_addr_t my_ip, int netbits, struct in6_addr my_net6)
 	struct in_addr net;
 	struct in_addr ipstart;
 
+#ifdef LINUX
 	struct in6_addr next_v6;
 	memcpy(&next_v6, &my_net6, sizeof(my_net6));
 	ipv6_addr_add(&next_v6, 1);
+#endif
 
 	for (i = 0; i < netbits; i++) {
 		netmask = (netmask << 1) | 1;
@@ -81,8 +87,10 @@ init_users(in_addr_t my_ip, int netbits, struct in6_addr my_net6)
 		users[i].disabled = 0;
 		users[i].active = 0;
 
+#ifdef LINUX
 		ipv6_addr_add(&next_v6, 1);
 		memcpy(&(users[i].tun_ip6), &next_v6, sizeof(struct in6_addr));
+#endif
 
  		/* Rest is reset on login ('V' packet) */
 	}

--- a/src/user.c
+++ b/src/user.c
@@ -51,7 +51,7 @@ init_users(in_addr_t my_ip, int netbits, struct in6_addr my_net6)
 
 	struct in6_addr next_v6;
 	memcpy(&next_v6, &my_net6, sizeof(my_net6));
-	inet6_addr_add(&next_v6, 1);
+	ipv6_addr_add(&next_v6, 1);
 
 	for (i = 0; i < netbits; i++) {
 		netmask = (netmask << 1) | 1;
@@ -80,7 +80,7 @@ init_users(in_addr_t my_ip, int netbits, struct in6_addr my_net6)
 		users[i].disabled = 0;
 		users[i].active = 0;
 
-		inet6_addr_add(&next_v6, 1);
+		ipv6_addr_add(&next_v6, 1);
 		memcpy(&(users[i].tun_ip6), &next_v6, sizeof(struct in6_addr));
 
  		/* Rest is reset on login ('V' packet) */
@@ -143,7 +143,7 @@ find_user_by_ip6(struct in6_addr ip)
 	for (i = 0; i < usercount; i++) {
 		if (users[i].active && !users[i].disabled &&
 			users[i].last_pkt + 60 > time(NULL) &&
-			inet6_addr_equals(&ip, &(users[i].tun_ip6))) {
+			ipv6_addr_equals(&ip, &(users[i].tun_ip6))) {
 			ret = i;
 			break;
 		}

--- a/src/user.h
+++ b/src/user.h
@@ -44,7 +44,10 @@ struct user {
 #ifdef LINUX
 	struct in6_addr tun_ip6;
 #endif
-	struct in_addr host;
+	union {
+			struct in_addr v4;
+			struct in6_addr v6;
+	} host;
 	struct query q;
 	struct query q_sendrealsoon;
 	int q_sendrealsoon_new;

--- a/src/user.h
+++ b/src/user.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2006-2009 Bjorn Andersson <flex@kryo.se>, Erik Ekman <yarrick@kryo.se>
+ * Copyright (c) 2011-2012 Julian Kranz <julian@juliankranz.de>
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -80,7 +81,9 @@ int init_users(in_addr_t my_ip, int netbits, struct in6_addr my_net6);
 const char* users_get_first_ip();
 int users_waiting_on_reply();
 int find_user_by_ip(uint32_t);
+#ifdef LINUX
 int find_user_by_ip6(struct in6_addr ip);
+#endif
 int all_users_waiting_to_send();
 int find_available_user();
 void user_switch_codec(int userid, struct encoder *enc);

--- a/src/user.h
+++ b/src/user.h
@@ -81,7 +81,7 @@ extern struct user *users;
 
 #ifdef LINUX
 int init_users(in_addr_t my_ip, int netbits, struct in6_addr my_net6);
-#elif
+#else
 int init_users(in_addr_t my_ip, int netbits);
 #endif
 const char* users_get_first_ip();

--- a/src/user.h
+++ b/src/user.h
@@ -41,7 +41,9 @@ struct user {
 	time_t last_pkt;
 	int seed;
 	in_addr_t tun_ip;
+#ifdef LINUX
 	struct in6_addr tun_ip6;
+#endif
 	struct in_addr host;
 	struct query q;
 	struct query q_sendrealsoon;
@@ -77,7 +79,11 @@ struct user {
 
 extern struct user *users;
 
+#ifdef LINUX
 int init_users(in_addr_t my_ip, int netbits, struct in6_addr my_net6);
+#elif
+int init_users(in_addr_t my_ip, int netbits);
+#endif
 const char* users_get_first_ip();
 int users_waiting_on_reply();
 int find_user_by_ip(uint32_t);

--- a/src/version.h
+++ b/src/version.h
@@ -20,6 +20,7 @@
 /* This is the version of the network protocol
    It is usually equal to the latest iodine version number */
 #define VERSION 0x00000502
+#define VERSION_V6 0x00000503
 
 #endif /* _VERSION_H_ */
 


### PR DESCRIPTION
The repo git://github.com/jucs/iodine.git started with a version of iodine from a few years ago, and added IPv6 support.  I'm not sure if these changes are useful, but in order to have a proper look at them I rebased them on top of the commit in yarrick/iodine from which they actually started, with some keywork expansions squashed and some generated files clipped.  The result is the branch jucs-ipv6-rebase in my repo, see above.

It cannot be merged automatically onto the current development tip (there are conflicts and such) but I thought it might be useful to have this information present when adding full IPv6 support.
