### PR TITLE
osflags: use pkg-config for systemd support

### DIFF
--- a/src/osflags
+++ b/src/osflags
@@ -19,7 +19,7 @@ link)
 		Linux)
 			FLAGS="";
 			[ -e /usr/include/selinux/selinux.h ] && FLAGS="$FLAGS -lselinux";
-			[ -e /usr/include/systemd/sd-daemon.h ] && FLAGS="$FLAGS -lsystemd-daemon";
+			[ -e /usr/include/systemd/sd-daemon.h ] && FLAGS="$FLAGS $(pkg-config --libs libsystemd-daemon)";
 			echo $FLAGS;
 		;;
 	esac


### PR DESCRIPTION
Recent versions of systemd don't ship with libsystemd-daemon.so anymore,
but instead use libsystemd.so for everything. This is obviously
problematic for using the same LDFLAGS on old systemd and new systemd.
So, they also ship compatability pkgconfig files, which use the old
names but return the new library. So, the most portable way to support
both old and new systemd is to use pkgconfig. It's not a problem either,
since systems that use systemd are bound to also have pkgconfig
installed.
