### PR TITLE
iodined.c: Fix automatically get external ip (-n auto)

### DIFF
--- a/src/iodined.c
+++ b/src/iodined.c
@@ -252,7 +252,7 @@ get_external_ip_by_stun(struct in_addr *ip, const char *stun_server)
 		if (res2 == 0) {
 			/* timeout */
 			res = 7;
-			continue;
+			break;
 		}
 		if (res2 != 1) {
 			res = 8;


### PR DESCRIPTION
Dear iodine maintainers,

I implement the -n auto to get external ip through STUN protocol. Please review this patch and see if it is good.

This patch isn't important now because I just noticed that you fix the problem I met in Debian.
In Debian, -n auto doesn't work because externalip.net is off. But you've already fix that.

But I still think using STUN might be good because it is quite common and standard.

Many Thanks,
Paul
