### PR TITLE
Fix compilation with systemd>=230 and systemd versions without compat-libs

### DIFF
--- a/src/osflags
+++ b/src/osflags
@@ -20,6 +20,7 @@ link)
 			FLAGS="";
 			[ -e /usr/include/selinux/selinux.h ] && FLAGS="$FLAGS -lselinux";
 			[ -e /usr/include/systemd/sd-daemon.h ] && FLAGS="$FLAGS $(pkg-config --libs libsystemd-daemon)";
+			[ -e /usr/include/systemd/sd-daemon.h ] && FLAGS="$FLAGS $(pkg-config --libs libsystemd)";
 			echo $FLAGS;
 		;;
 	esac


### PR DESCRIPTION
This fixes https://dev.kryo.se/iodine/ticket/123

Be advised though that I have only tested this on Archlinux with systemd package version 229-3.