### PR TITLE
simple speed boost for legacy mode

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1121,7 +1121,7 @@ client_tunnel(int tun_fd, int dns_fd)
 		}
 
 		FD_ZERO(&fds);
-		if (!is_sending() || outchunkresent >= 2) {
+		if (!is_sending() || outchunkresent >= 2 || !lazymode) {
 			/* If re-sending upstream data, chances are that
 			   we're several seconds behind already and TCP
 			   will start filling tun buffer with (useless)


### PR DESCRIPTION
Throughput is increased in legacy mode by dropping packets if the client is not ready to send immediately.  Upstream packets must conform to the ping-pong traffic pattern or be dropped, and TCP recovers gracefully from intentional packet loss by sending some segments out of order.  This is tremendously beneficial on Wi-Fi, where latency is variable, if the only available DNS server will only tolerate legacy mode.  Personally I have seen this simple change double my download speed.