### PR TITLE
protect options from replay attack

### DIFF
--- a/src/iodined.c
+++ b/src/iodined.c
@@ -263,6 +263,19 @@ check_authenticated_user_and_ip(int userid, struct query *q)
 	return 0;
 }
 
+static int
+check_authenticated_user_and_ip_and_options(int userid, struct query *q)
+{
+	int res = check_authenticated_user_and_ip(userid, q);
+	if (res || check_ip)
+		return res;
+
+	if (users[userid].options_locked)
+		return 1;
+
+	return 0;
+}
+
 static void
 send_raw(int fd, char *buf, int buflen, int user, int cmd, struct query *q)
 {
@@ -973,7 +986,7 @@ handle_null_request(int tun_fd, int dns_fd, struct dnsfd *dns_fds, struct query 
 
 		userid = b32_8to5(in[1]);
 
-		if (check_authenticated_user_and_ip(userid, q) != 0) {
+		if (check_authenticated_user_and_ip_and_options(userid, q) != 0) {
 			write_dns(dns_fd, q, "BADIP", 5, 'T');
 			return; /* illegal id */
 		}
@@ -1014,7 +1027,7 @@ handle_null_request(int tun_fd, int dns_fd, struct dnsfd *dns_fds, struct query 
 
 		userid = b32_8to5(in[1]);
 
-		if (check_authenticated_user_and_ip(userid, q) != 0) {
+		if (check_authenticated_user_and_ip_and_options(userid, q) != 0) {
 			write_dns(dns_fd, q, "BADIP", 5, 'T');
 			return; /* illegal id */
 		}
@@ -1177,7 +1190,7 @@ handle_null_request(int tun_fd, int dns_fd, struct dnsfd *dns_fds, struct query 
 
 		/* Downstream fragsize packet */
 		userid = unpacked[0];
-		if (check_authenticated_user_and_ip(userid, q) != 0) {
+		if (check_authenticated_user_and_ip_and_options(userid, q) != 0) {
 			write_dns(dns_fd, q, "BADIP", 5, 'T');
 			return; /* illegal id */
 		}
@@ -1187,6 +1200,7 @@ handle_null_request(int tun_fd, int dns_fd, struct dnsfd *dns_fds, struct query 
 			write_dns(dns_fd, q, "BADFRAG", 7, users[userid].downenc);
 		} else {
 			users[userid].fragsize = max_frag_size;
+			users[userid].options_locked = 1;
 			write_dns(dns_fd, q, &unpacked[1], 2, users[userid].downenc);
 		}
 		return;

--- a/src/user.c
+++ b/src/user.c
@@ -77,6 +77,7 @@ init_users(in_addr_t my_ip, int netbits)
 		users[i].disabled = 0;
 		users[i].authenticated = 0;
 		users[i].authenticated_raw = 0;
+		users[i].options_locked = 0;
 		users[i].active = 0;
  		/* Rest is reset on login ('V' packet) */
 	}
@@ -156,6 +157,7 @@ find_available_user()
 			users[i].active = 1;
 			users[i].authenticated = 0;
 			users[i].authenticated_raw = 0;
+			users[i].options_locked = 0;
 			users[i].last_pkt = time(NULL);
 			users[i].fragsize = 4096;
 			users[i].conn = CONN_DNS_NULL;

--- a/src/user.h
+++ b/src/user.h
@@ -39,6 +39,7 @@ struct tun_user {
 	int active;
 	int authenticated;
 	int authenticated_raw;
+	int options_locked;
 	int disabled;
 	time_t last_pkt;
 	int seed;


### PR DESCRIPTION
Trying to determine why long-running sessions inexplicably become slow, I ran tcpdump and found unsolicited DNS queries beginning with the letter N were severely reducing the downstream fragment size.

When using carrier-grade DNS, the server is especially vulnerable to replay attacks that abuse the options commands (DNS queries beginning with N or O or S).  I suggest refusing options commands after the negotiation of options has completed.
