### PR TITLE
Add android build files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /src/base64u.c
 /src/base64u.h
 /tests/test
+*.o.d
+/src/obj/local/*/iodine
+/src/libs/*/iodine


### PR DESCRIPTION
The build files from make cross-android are not included in the .gitignore file. 