### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1266,7 +1266,7 @@ send_ip_request(int fd, int userid)
 	buf[4] = b32_5to8((rand_seed ) & 0x1f);
 	rand_seed++;
 
-	strncat(buf, topdomain, 512 - strlen(buf));
+	strncat(buf, topdomain, 511 - strlen(buf));
 	send_query(fd, buf);
 }
 
@@ -1290,9 +1290,9 @@ send_upenctest(int fd, const char *s)
 	buf[3] = b32_5to8((rand_seed ) & 0x1f);
 	rand_seed++;
 
-	strncat(buf, s, 512);
-	strncat(buf, ".", 512);
-	strncat(buf, topdomain, 512 - strlen(buf));
+	strncat(buf, s, 511);
+	strncat(buf, ".", 511);
+	strncat(buf, topdomain, 511 - strlen(buf));
 	send_query(fd, buf);
 }
 
@@ -1310,7 +1310,7 @@ send_downenctest(int fd, char downenc, int variant, char *s, int slen)
 	buf[5] = b32_5to8((rand_seed ) & 0x1f);
 	rand_seed++;
 
-	strncat(buf, topdomain, 512 - strlen(buf));
+	strncat(buf, topdomain, 511 - strlen(buf));
 	send_query(fd, buf);
 }
 
@@ -1326,7 +1326,7 @@ send_codec_switch(int fd, int userid, int bits)
 	buf[5] = b32_5to8((rand_seed ) & 0x1f);
 	rand_seed++;
 
-	strncat(buf, topdomain, 512 - strlen(buf));
+	strncat(buf, topdomain, 511 - strlen(buf));
 	send_query(fd, buf);
 }
 
@@ -1343,7 +1343,7 @@ send_downenc_switch(int fd, int userid)
 	buf[5] = b32_5to8((rand_seed ) & 0x1f);
 	rand_seed++;
 
-	strncat(buf, topdomain, 512 - strlen(buf));
+	strncat(buf, topdomain, 511 - strlen(buf));
 	send_query(fd, buf);
 }
 
@@ -1363,7 +1363,7 @@ send_lazy_switch(int fd, int userid)
 	buf[5] = b32_5to8((rand_seed ) & 0x1f);
 	rand_seed++;
 
-	strncat(buf, topdomain, 512 - strlen(buf));
+	strncat(buf, topdomain, 511 - strlen(buf));
 	send_query(fd, buf);
 }
 

--- a/src/encoding.c
+++ b/src/encoding.c
@@ -16,17 +16,20 @@
  */
 
 #include <string.h>
+#include <assert.h>
 #include "common.h"
 #include "encoding.h"
 
 int build_hostname(char *buf, size_t buflen, const char *data,
 		   const size_t datalen, const char *topdomain,
-		   const struct encoder *encoder, int maxlen)
+		   const struct encoder *encoder, size_t maxlen)
 {
 	size_t space;
 	char *b;
+	size_t topdomainlen = strlen(topdomain);
+	char *bufstart = buf;
 
-	space = MIN((size_t)maxlen, buflen) - strlen(topdomain) - 8;
+	space = MIN(maxlen, buflen) - topdomainlen - 8;
 	/* 8 = 5 max header length + 1 dot before topdomain + 2 safety */
 
 	if (!encoder->places_dots)
@@ -49,7 +52,8 @@ int build_hostname(char *buf, size_t buflen, const char *data,
 	b++;
 	/* move b ahead of the string so we can copy to it */
 
-	strncpy(b, topdomain, strlen(topdomain)+1);
+	assert((*b - *bufstart) >= topdomainlen+1);
+	strncpy(b, topdomain, topdomainlen+1);
 
 	return space;
 }

--- a/src/encoding.h
+++ b/src/encoding.h
@@ -49,7 +49,7 @@ struct encoder {
 };
 
 int build_hostname(char *, size_t, const char *, const size_t, const char *,
-		   const struct encoder *, int);
+		   const struct encoder *, size_t);
 int unpack_data(char *, size_t, char *, size_t, const struct encoder *);
 int inline_dotify(char *, size_t);
 int inline_undotify(char *, size_t);

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2391,9 +2391,9 @@ main(int argc, char **argv)
 	int retval;
 	int max_idle_time = 0;
 	struct sockaddr_storage dns4addr;
-	int dns4addr_len;
+	int dns4addr_len = 0;
 	struct sockaddr_storage dns6addr;
-	int dns6addr_len;
+	int dns6addr_len = 0;
 #ifdef HAVE_SYSTEMD
 	int nb_fds;
 #endif

--- a/src/user.c
+++ b/src/user.c
@@ -23,6 +23,7 @@
 #include <signal.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <assert.h>
 
 #ifdef WINDOWS32
 #include <winsock2.h>
@@ -63,11 +64,15 @@ int init_users(in_addr_t my_ip, int netbits)
 	for (i = 0; i < usercount; i++) {
 		in_addr_t ip;
 		users[i].id = i;
+		assert(0 <= (i + skip + 1));
+		assert(255 >= (i + skip + 1));
 		snprintf(newip, sizeof(newip), "0.0.0.%d", i + skip + 1);
 		ip = ipstart.s_addr + inet_addr(newip);
 		if (ip == my_ip && skip == 0) {
 			/* This IP was taken by iodined */
 			skip++;
+			assert(0 <= (i + skip + 1));
+			assert(255 >= (i + skip + 1));
 			snprintf(newip, sizeof(newip), "0.0.0.%d", i + skip + 1);
 			ip = ipstart.s_addr + inet_addr(newip);
 		}


### PR DESCRIPTION
I've noticed a bunch of compiler warnings that discomforted me, so I've tried to get rid of them. Please double-check before merging as I no experience with C whatsoever.

I've used the resulting iodine and iodined binaries for a few test connections on Archlinux x86_64 and didn't experience any unexpected behaviour, but that obviously can't replace a proper review of my changes.