### PR TITLE
Fix compiling error on Alpine

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -58,7 +58,7 @@ const unsigned char raw_header[RAW_HDR_LEN] = { 0x10, 0xd1, 0x9e, 0x00 };
 
 /* daemon(3) exists only in 4.4BSD or later, and in GNU libc */
 #if !defined(ANDROID) && !defined(WINDOWS32) && !(defined(BSD) && (BSD >= 199306)) && !defined(__GLIBC__)
-static int daemon(int nochdir, int noclose)
+int daemon(int nochdir, int noclose)
 {
  	int fd, i;
 


### PR DESCRIPTION
> common.c:61:12: error: static declaration of 'daemon' follows non-static declaration
>  static int daemon(int nochdir, int noclose)
>             ^~~~~~
> In file included from /usr/include/fortify/unistd.h:22,
>                  from common.c:26:
> /usr/include/unistd.h:170:5: note: previous declaration of 'daemon' was here
>  int daemon(int, int);
>      ^~~~~~
> make[1]: *** [Makefile:33: common.o] Error 1
> make[1]: Leaving directory '/iodine/src'
> make: *** [Makefile:20: all] Error 2

The unistd.h on Alpine Linux seems different from other distros.