### PR TITLE
fix #38: responds to NS/A with IP from -n argument

### DIFF
--- a/src/iodined.c
+++ b/src/iodined.c
@@ -1548,8 +1548,9 @@ handle_ns_request(int dns_fd, struct query *q)
 	if (ns_ip != INADDR_ANY) {
 		/* If ns_ip set, overwrite destination addr with it.
 		 * Destination addr will be sent as additional record (A, IN) */
-		struct sockaddr_in *addr = (struct sockaddr_in *) &q->destination;
-		memcpy(&addr->sin_addr, &ns_ip, sizeof(ns_ip));
+		struct sockaddr_in *addr = (struct sockaddr_in *) &q->destination; /* probably not needed */
+		memcpy(&q->destination, &ns_ip, sizeof(ns_ip));
+		memcpy(&addr->sin_addr, &ns_ip, sizeof(ns_ip)); /* probably not needed */
 	}
 
 	len = dns_encode_ns_response(buf, sizeof(buf), q, topdomain);
@@ -1582,8 +1583,9 @@ handle_a_request(int dns_fd, struct query *q, int fakeip)
 	} else if (ns_ip != INADDR_ANY) {
 		/* If ns_ip set, overwrite destination addr with it.
 		 * Destination addr will be sent as additional record (A, IN) */
-		struct sockaddr_in *addr = (struct sockaddr_in *) &q->destination;
-		memcpy(&addr->sin_addr, &ns_ip, sizeof(ns_ip));
+		struct sockaddr_in *addr = (struct sockaddr_in *) &q->destination; /* probably not needed */
+		memcpy(&q->destination, &ns_ip, sizeof(ns_ip));
+		memcpy(&addr->sin_addr, &ns_ip, sizeof(ns_ip)); /* probably not needed */
 	}
 
 	len = dns_encode_a_response(buf, sizeof(buf), q);

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -1548,9 +1548,7 @@ handle_ns_request(int dns_fd, struct query *q)
 	if (ns_ip != INADDR_ANY) {
 		/* If ns_ip set, overwrite destination addr with it.
 		 * Destination addr will be sent as additional record (A, IN) */
-		struct sockaddr_in *addr = (struct sockaddr_in *) &q->destination; /* probably not needed */
 		memcpy(&q->destination, &ns_ip, sizeof(ns_ip));
-		memcpy(&addr->sin_addr, &ns_ip, sizeof(ns_ip)); /* probably not needed */
 	}
 
 	len = dns_encode_ns_response(buf, sizeof(buf), q, topdomain);
@@ -1583,9 +1581,7 @@ handle_a_request(int dns_fd, struct query *q, int fakeip)
 	} else if (ns_ip != INADDR_ANY) {
 		/* If ns_ip set, overwrite destination addr with it.
 		 * Destination addr will be sent as additional record (A, IN) */
-		struct sockaddr_in *addr = (struct sockaddr_in *) &q->destination; /* probably not needed */
 		memcpy(&q->destination, &ns_ip, sizeof(ns_ip));
-		memcpy(&addr->sin_addr, &ns_ip, sizeof(ns_ip)); /* probably not needed */
 	}
 
 	len = dns_encode_a_response(buf, sizeof(buf), q);


### PR DESCRIPTION
As described in issue #38, DNS type NS requests to iodined got responses with additional IP that was incorrect (always 2.0.0.0) if the -n argument switch was used to specify a custom IP address. The same applied to A requests (for ns.topdomain); the IP was always 2.0.0.0 because of wrong memory copying.

This commit fix solves this issue by correctly memory copying ns_ip to query destination (&q->destination).