### PR TITLE
Add title to license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+ISC License
+
 Copyright (c) 2006-2020 iodine authors
 
 Permission to use, copy, modify, and/or distribute this software for any purpose


### PR DESCRIPTION
The title is not legally mandated, but it's convenient for human consumption, and provides additional metadata; for that reason, it is typically included in the template text of this license, as recommended by [OSI](https://opensource.org/licenses/isc-license), [SPDX](https://spdx.org/licenses/ISC.html#licenseText), [choosealicense.com](https://choosealicense.com/licenses/isc/), and others.

***Note**: This PR is part of my personal project to improve the consistency and visibility of the ISC license in open source projects. See https://github.com/github/choosealicense.com/issues/377 for more details.*