### PR TITLE
Update client and server to allow forwarding IPv6 packets within the tunnel

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ iodine - https://code.kryo.se/iodine
 
 CHANGES:
 
-master:
+2021-12-26: 0.8.0 "Uncaptive portal"
 	- Mac OS X: Support native utun VPN devices. Patch by
 		Peter Sagerson, ported from OpenVPN by Catalin Patulea.
 	- Fix compilation failure on kFreeBSD and Hurd, by Gregor Herrmann

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@ iodine - https://code.kryo.se/iodine
 
 CHANGES:
 
+2021-12-26: master
+        - switched to master branch
+
 2021-12-26: 0.8.0 "Uncaptive portal"
 	- Mac OS X: Support native utun VPN devices. Patch by
 		Peter Sagerson, ported from OpenVPN by Catalin Patulea.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,10 +5,7 @@ iodine - https://code.kryo.se/iodine
 
 CHANGES:
 
-2021-12-26: master
-        - switched to master branch
-
-2021-12-26: 0.8.0 "Uncaptive portal"
+master:
 	- Mac OS X: Support native utun VPN devices. Patch by
 		Peter Sagerson, ported from OpenVPN by Catalin Patulea.
 	- Fix compilation failure on kFreeBSD and Hurd, by Gregor Herrmann

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2006-2020 iodine authors
+Copyright (c) 2006-2021 iodine authors
 
 Permission to use, copy, modify, and/or distribute this software for any purpose
 with or without fee is hereby granted, provided that the above copyright notice

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ end of the tunnel. In this case, `ping 192.168.99.1` from the iodine client, and
 ### MISC. INFO
 
 #### IPv6
-The data inside the tunnel is IPv4 only.
+The data inside the tunnel may be IPv4 or IPv6.
 
 The server listens to both IPv4 and IPv6 for incoming requests by default.
 Use options `-4` or `-6` to only listen on one protocol. Raw mode will be
@@ -140,6 +140,14 @@ to your DNS setup. Extending the example above would look like this:
 	t1		IN	NS	t1ns.mydomain.com.		; note the dot!
 	t1ns		IN	A	10.15.213.99
 	t1ns		IN	AAAA	2001:db8::1001:99
+
+On the server, specify -S followed by an IPv6 address that will be the server end
+of the IPv6 pool to allocate to clients. The server only supports a /64 subnet 
+mask, which is assumed and can be omitted. The first 64 bits are the network from
+which IPv6 addresses are allocated from.
+
+The client will automatically check for IPv6 capability on the server and 
+assign the allocated address to its tunnel interface. No flags are needed.
 
 #### Routing
 It is possible to route all traffic through the DNS tunnel. To do this, first

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ ARCH = `uname -m`
 HEAD_COMMIT = `git rev-parse --short HEAD`
 
 LIBPATH = -L.
-LDFLAGS +=  -lz `sh osflags $(TARGETOS) link` $(LIBPATH)
+LDFLAGS +=  -lz `sh osflags $(TARGETOS) link` $(LIBPATH) -lm
 CFLAGS += -std=c99 -c -g -Wall -D$(OS) -pedantic `sh osflags $(TARGETOS) cflags` -DGITREVISION=\"$(HEAD_COMMIT)\"
 CFLAGS += -Wstrict-prototypes -Wtype-limits -Wmissing-declarations -Wmissing-prototypes
 

--- a/src/client.c
+++ b/src/client.c
@@ -1374,7 +1374,7 @@ handshake_version(int dns_fd, int *seed)
 }
 
 static int
-handshake_login(int dns_fd, int seed)
+handshake_login(int dns_fd, int seed, int forward_v6)
 {
 	char in[4096];
 	char login[16];
@@ -1405,7 +1405,7 @@ handshake_login(int dns_fd, int seed)
 
 				server[64] = 0;
 				client[64] = 0;
-				if (tun_setip(client, server, netmask) == 0 &&
+				if (tun_setip(client, server, netmask, forward_v6) == 0 &&
 					tun_setmtu(mtu) == 0) {
 
 					fprintf(stderr, "Server tunnel IP is %s\n", server);
@@ -2326,7 +2326,7 @@ handshake_set_fragsize(int dns_fd, int fragsize)
 }
 
 int
-client_handshake(int dns_fd, int raw_mode, int autodetect_frag_size, int fragsize)
+client_handshake(int dns_fd, int raw_mode, int autodetect_frag_size, int fragsize, int forward_v6)
 {
 	int seed;
 	int upcodec;
@@ -2349,7 +2349,7 @@ client_handshake(int dns_fd, int raw_mode, int autodetect_frag_size, int fragsiz
 		return r;
 	}
 
-	r = handshake_login(dns_fd, seed);
+	r = handshake_login(dns_fd, seed, forward_v6);
 	if (r) {
 		return r;
 	}

--- a/src/client.c
+++ b/src/client.c
@@ -28,6 +28,8 @@
 #include <fcntl.h>
 #include <zlib.h>
 #include <time.h>
+#include <stdbool.h>
+
 
 #ifdef WINDOWS32
 #include "windows.h"
@@ -101,6 +103,7 @@ static time_t lastdownstreamtime;
 static long send_query_sendcnt = -1;
 static long send_query_recvcnt = 0;
 static int hostname_maxlen = 0xFF;
+static bool use_v6 = false;
 
 void
 client_init()
@@ -1374,7 +1377,7 @@ handshake_version(int dns_fd, int *seed)
 }
 
 static int
-handshake_login(int dns_fd, int seed, int forward_v6)
+handshake_login(int dns_fd, int seed)
 {
 	char in[4096];
 	char login[16];
@@ -1405,7 +1408,7 @@ handshake_login(int dns_fd, int seed, int forward_v6)
 
 				server[64] = 0;
 				client[64] = 0;
-				if (tun_setip(client, server, netmask, forward_v6) == 0 &&
+				if (tun_setip(client, server, netmask) == 0 &&
 					tun_setmtu(mtu) == 0) {
 
 					fprintf(stderr, "Server tunnel IP is %s\n", server);
@@ -2326,7 +2329,7 @@ handshake_set_fragsize(int dns_fd, int fragsize)
 }
 
 int
-client_handshake(int dns_fd, int raw_mode, int autodetect_frag_size, int fragsize, int forward_v6)
+client_handshake(int dns_fd, int raw_mode, int autodetect_frag_size, int fragsize)
 {
 	int seed;
 	int upcodec;
@@ -2349,7 +2352,7 @@ client_handshake(int dns_fd, int raw_mode, int autodetect_frag_size, int fragsiz
 		return r;
 	}
 
-	r = handshake_login(dns_fd, seed, forward_v6);
+	r = handshake_login(dns_fd, seed);
 	if (r) {
 		return r;
 	}
@@ -2414,8 +2417,72 @@ client_handshake(int dns_fd, int raw_mode, int autodetect_frag_size, int fragsiz
 		handshake_set_fragsize(dns_fd, fragsize);
 		if (!running)
 			return -1;
+
+		handshake_check_v6(dns_fd);
+		if (!running)
+			return -1;
 	}
 
 	return 0;
 }
 
+static
+void send_v6_probe(int dns_fd)
+{
+  char data[4096];
+
+	data[0] = userid;
+
+	send_packet(dns_fd, 'g', data, sizeof(data));
+}
+
+int
+handshake_check_v6(int dns_fd)
+{
+	char in[4096];
+	char server6[1024];
+	char client6[1024];
+	int i;
+	int read;
+	int netmask6 = 0;
+
+	fprintf(stderr, "Autoprobing server IPV6 tunnel support\n");
+
+	for (i = 0; running && i < 5; i++) {
+
+     send_v6_probe(dns_fd);
+
+     read = handshake_waitdns(dns_fd, in, sizeof(in), 'g', 'G', i+1);
+
+		 if (read > 0) {
+
+        /*
+			   * including a terminating dash to allow for future IPv6 options, e.g.
+			   * netmask. Currently assumes /64. MTU is taken from the IPv4 handshake.
+			   * A future IPv6-only implementation would need to pass mtu
+			   * in the IPV6 handshake.
+			   */
+
+			  if (sscanf(in, "%512[^-]-%512[^-]-%d", server6, client6, &netmask6) == 3) {
+
+					 fprintf(stderr, "Server tunnel IPv6 is %s\n", server6);
+					 fprintf(stderr, "Local tunnel IPv6 is %s\n", client6);
+
+					 if (tun_setip6(client6, server6, netmask6) == 0) {
+
+              use_v6 = true;
+							return 0;
+				   } else {
+				      errx(4, "Failed to set IPv6 tunnel address");
+				   }
+			  } else {
+				   fprintf(stderr, "Received bad IPv6 tunnel handshake\n");
+			  }
+		 }
+
+		 fprintf(stderr, "Retrying IPv6 tunnel handshake...\n");
+	}
+	if (!running)
+		return -1;
+   return 0;
+}

--- a/src/client.h
+++ b/src/client.h
@@ -35,7 +35,7 @@ void client_set_lazymode(int lazy_mode);
 void client_set_hostname_maxlen(int i);
 
 int client_handshake(int dns_fd, int raw_mode, int autodetect_frag_size,
-		     int fragsize);
+		     int fragsize, int forward_v6);
 int client_tunnel(int tun_fd, int dns_fd);
 
 #endif

--- a/src/client.h
+++ b/src/client.h
@@ -35,7 +35,7 @@ void client_set_lazymode(int lazy_mode);
 void client_set_hostname_maxlen(int i);
 
 int client_handshake(int dns_fd, int raw_mode, int autodetect_frag_size,
-		     int fragsize, int forward_v6);
+		     int fragsize);
 int client_tunnel(int tun_fd, int dns_fd);
-
+int handshake_check_v6(int tun_fd);
 #endif

--- a/src/common.c
+++ b/src/common.c
@@ -13,6 +13,8 @@
  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *
  */
 
 #include <time.h>
@@ -556,4 +558,18 @@ fd_set_close_on_exec(int fd)
 		err(4, "Failed to set fd flags");
 }
 #endif
+
+bool
+isV6AddrSet(struct in6_addr *ip6)
+{
+       int i;
+
+       for (i = 0; i < sizeof(ip6->s6_addr); i++) {
+          if (ip6->s6_addr[i] != 0) { 
+             return true;
+          }
+       }
+       
+       return false;
+}
 

--- a/src/common.h
+++ b/src/common.h
@@ -33,6 +33,7 @@
 extern const unsigned char raw_header[RAW_HDR_LEN];
 
 #include <stdarg.h>
+#include <stdbool.h>
 #ifdef WINDOWS32
 #include "windows.h"
 #else
@@ -129,6 +130,7 @@ void read_password(char*, size_t);
 int check_topdomain(char *, int, char **);
 
 int query_datalen(const char *qname, const char *topdomain);
+bool isV6AddrSet(struct in6_addr *);
 
 #if defined(WINDOWS32) || defined(ANDROID)
 #ifndef ANDROID

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -195,7 +195,7 @@ int main(int argc, char **argv)
 		__progname++;
 #endif
 
-	while ((choice = getopt(argc, argv, "46vfhruS:t:d:R:P:m:M:F:T:O:L:I")) != -1) {
+	while ((choice = getopt(argc, argv, "t:d:R:P:m:M:z:F:T:O:L:I:46vfhruS")) != -1) {
 		switch(choice) {
 		case '4':
 			nameserv_family = AF_INET;
@@ -220,6 +220,9 @@ int main(int argc, char **argv)
 		case 'u':
 			username = optarg;
 			break;
+                case 'S':
+                        forward_v6 = 1;
+                        break;
 		case 't':
 			newroot = optarg;
 			break;
@@ -271,9 +274,6 @@ int main(int argc, char **argv)
 			if (!lazymode)
 				selecttimeout = 1;
 			break;
-                case 'S':
-                        forward_v6 = 1;
-                        break; 
 		case 'I':
 			selecttimeout = atoi(optarg);
 			if (selecttimeout < 1)

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -372,7 +372,7 @@ int main(int argc, char **argv)
 	fprintf(stderr, "Sending DNS queries for %s to %s\n",
 		topdomain, format_addr(&nameservaddr, nameservaddr_len));
 
-	if (client_handshake(dns_fd, raw_mode, autodetect_frag_size, max_downstream_frag_size)) {
+	if (client_handshake(dns_fd, raw_mode, autodetect_frag_size, max_downstream_frag_size, forward_v6)) {
 		retval = 1;
 		goto cleanup2;
 	}

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -72,7 +72,7 @@ static void help(FILE *stream, bool verbose)
 {
 	fprintf(stream,
 		"iodine IP over DNS tunneling client\n\n"
-		"Usage: %s [-46fhrvS] [-u user] [-t chrootdir] [-d device] [-P password]\n"
+		"Usage: %s [-46fhrv] [-u user] [-t chrootdir] [-d device] [-P password]\n"
 		"              [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec]\n"
 		"              [-z context] [-F pidfile] [nameserver] topdomain\n", __progname);
 
@@ -100,7 +100,6 @@ static void help(FILE *stream, bool verbose)
 		"  -t dir to chroot to directory dir\n"
 		"  -d device to set tunnel device name\n"
 		"  -z context, to apply specified SELinux context after initialization\n"
-                "  -S enable forwarding of IPv6 packets within the tunnel\n"
 		"  -F pidfile to write pid to a file\n\n"
 		"nameserver is the IP number/hostname of the relaying nameserver. If absent,\n"
 		"           /etc/resolv.conf is used\n"
@@ -153,7 +152,6 @@ int main(int argc, char **argv)
 	struct sockaddr_storage nameservaddr;
 	int nameservaddr_len;
 	int nameserv_family;
-        int forward_v6;
 
 	nameserv_host = NULL;
 	topdomain = NULL;
@@ -178,7 +176,6 @@ int main(int argc, char **argv)
 	selecttimeout = 4;
 	hostname_maxlen = 0xFF;
 	nameserv_family = AF_UNSPEC;
-        forward_v6 = 0;
 
 #ifdef WINDOWS32
 	WSAStartup(req_version, &wsa_data);
@@ -195,7 +192,8 @@ int main(int argc, char **argv)
 		__progname++;
 #endif
 
-	while ((choice = getopt(argc, argv, "t:d:R:P:m:M:z:F:T:O:L:I:46vfhruS")) != -1) {
+	while ((choice = getopt(argc, argv, "46vfhru:t:d:R:P:m:M:F:T:O:L:I:")) != -1) {
+
 		switch(choice) {
 		case '4':
 			nameserv_family = AF_INET;
@@ -220,9 +218,6 @@ int main(int argc, char **argv)
 		case 'u':
 			username = optarg;
 			break;
-                case 'S':
-                        forward_v6 = 1;
-                        break;
 		case 't':
 			newroot = optarg;
 			break;
@@ -372,7 +367,7 @@ int main(int argc, char **argv)
 	fprintf(stderr, "Sending DNS queries for %s to %s\n",
 		topdomain, format_addr(&nameservaddr, nameservaddr_len));
 
-	if (client_handshake(dns_fd, raw_mode, autodetect_frag_size, max_downstream_frag_size, forward_v6)) {
+	if (client_handshake(dns_fd, raw_mode, autodetect_frag_size, max_downstream_frag_size)) {
 		retval = 1;
 		goto cleanup2;
 	}

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -72,7 +72,7 @@ static void help(FILE *stream, bool verbose)
 {
 	fprintf(stream,
 		"iodine IP over DNS tunneling client\n\n"
-		"Usage: %s [-46fhrv] [-u user] [-t chrootdir] [-d device] [-P password]\n"
+		"Usage: %s [-46fhrvS] [-u user] [-t chrootdir] [-d device] [-P password]\n"
 		"              [-m maxfragsize] [-M maxlen] [-T type] [-O enc] [-L 0|1] [-I sec]\n"
 		"              [-z context] [-F pidfile] [nameserver] topdomain\n", __progname);
 
@@ -100,6 +100,7 @@ static void help(FILE *stream, bool verbose)
 		"  -t dir to chroot to directory dir\n"
 		"  -d device to set tunnel device name\n"
 		"  -z context, to apply specified SELinux context after initialization\n"
+                "  -S enable forwarding of IPv6 packets within the tunnel\n"
 		"  -F pidfile to write pid to a file\n\n"
 		"nameserver is the IP number/hostname of the relaying nameserver. If absent,\n"
 		"           /etc/resolv.conf is used\n"
@@ -152,6 +153,7 @@ int main(int argc, char **argv)
 	struct sockaddr_storage nameservaddr;
 	int nameservaddr_len;
 	int nameserv_family;
+        int forward_v6;
 
 	nameserv_host = NULL;
 	topdomain = NULL;
@@ -176,6 +178,7 @@ int main(int argc, char **argv)
 	selecttimeout = 4;
 	hostname_maxlen = 0xFF;
 	nameserv_family = AF_UNSPEC;
+        forward_v6 = 0;
 
 #ifdef WINDOWS32
 	WSAStartup(req_version, &wsa_data);
@@ -192,7 +195,7 @@ int main(int argc, char **argv)
 		__progname++;
 #endif
 
-	while ((choice = getopt(argc, argv, "46vfhru:t:d:R:P:m:M:F:T:O:L:I:")) != -1) {
+	while ((choice = getopt(argc, argv, "46vfhru:t:d:R:P:m:M:F:T:O:L:I:s")) != -1) {
 		switch(choice) {
 		case '4':
 			nameserv_family = AF_INET;
@@ -268,6 +271,9 @@ int main(int argc, char **argv)
 			if (!lazymode)
 				selecttimeout = 1;
 			break;
+                case 'S':
+                        forward_v6 = 1;
+                        break; 
 		case 'I':
 			selecttimeout = atoi(optarg);
 			if (selecttimeout < 1)

--- a/src/iodine.c
+++ b/src/iodine.c
@@ -195,7 +195,7 @@ int main(int argc, char **argv)
 		__progname++;
 #endif
 
-	while ((choice = getopt(argc, argv, "46vfhru:t:d:R:P:m:M:F:T:O:L:I:s")) != -1) {
+	while ((choice = getopt(argc, argv, "46vfhruS:t:d:R:P:m:M:F:T:O:L:I")) != -1) {
 		switch(choice) {
 		case '4':
 			nameserv_family = AF_INET;

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2274,7 +2274,7 @@ write_dns(int fd, struct query *q, const char *data, int datalen, char downenc)
 static void print_usage(FILE *stream)
 {
 	fprintf(stream,
-		"Usage: %s [-46cDfsv] [-u user] [-t chrootdir] [-d device] [-m mtu]\n"
+		"Usage: %s [-46cDfsvS] [-u user] [-t chrootdir] [-d device] [-m mtu]\n"
 		"               [-z context] [-l ipv4 listen address] [-L ipv6 listen address]\n"
 		"               [-p port] [-n auto|external_ip] [-b dnsport] [-P password]\n"
 		"               [-F pidfile] [-i max idle time] tunnel_ip[/netmask] topdomain\n",
@@ -2390,6 +2390,7 @@ main(int argc, char **argv)
 	int dns4addr_len;
 	struct sockaddr_storage dns6addr;
 	int dns6addr_len;
+        int forward_v6;
 #ifdef HAVE_SYSTEMD
 	int nb_fds;
 #endif
@@ -2418,7 +2419,7 @@ main(int argc, char **argv)
 	debug = 0;
 	netmask = 27;
 	pidfile = NULL;
-
+        forward_v6 = 0;
 	retval = 0;
 
 #ifdef WINDOWS32
@@ -2507,6 +2508,9 @@ main(int argc, char **argv)
 			/* XXX: find better way of cleaning up ps(1) */
 			memset(optarg, 0, strlen(optarg));
 			break;
+                case 'S':
+                        forward_v6 = 1;
+                        break;
 		case 'z':
 			context = optarg;
 			break;
@@ -2674,7 +2678,7 @@ main(int argc, char **argv)
 	}
 	if (!skipipconfig) {
 		const char *other_ip = users_get_first_ip();
-		if (tun_setip(argv[0], other_ip, netmask) != 0 || tun_setmtu(mtu) != 0) {
+		if (tun_setip(argv[0], other_ip, netmask, forward_v6) != 0 || tun_setmtu(mtu) != 0) {
 			retval = 1;
 			free((void*) other_ip);
 			goto cleanup;

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2451,7 +2451,7 @@ main(int argc, char **argv)
 	srand(time(NULL));
 	fw_query_init();
 
-	while ((choice = getopt(argc, argv, "46vcsSfhDu:t:d:m:l:L:p:n:b:P:z:F:i:")) != -1) {
+	while ((choice = getopt(argc, argv, "t:d:m:l:L:p:n:b:P:z:F:i:46vcsSfhDu")) != -1) {
 		switch(choice) {
 		case '4':
 			addrfamily = AF_INET;

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2333,6 +2333,7 @@ static void help(FILE *stream)
 		"  -b port to forward normal DNS queries to (on localhost)\n"
 		"  -P password used for authentication (max 32 chars will be used)\n"
 		"  -F pidfile to write pid to a file\n"
+		"  -S enable forwarding of IPv6 packets within the tunnel\n"
 		"  -i maximum idle time before shutting down\n\n"
 		"tunnel_ip is the IP number of the local tunnel interface.\n"
 		"   /netmask sets the size of the tunnel network.\n"

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -90,8 +90,8 @@ static int my_mtu;
 static in_addr_t my_ip;
 
 char display_ip6[INET6_ADDRSTRLEN];
-char *display_ip6_buffer;
-char *ip6_netmask_buffer;
+char *display_ip6_buffer = NULL;
+char *ip6_netmask_buffer = NULL;
 
 static struct in6_addr my_ip6;
 static int netmask;
@@ -2590,21 +2590,25 @@ main(int argc, char **argv)
 	}
 
 	
-	ip6_netmask_buffer = strchr(display_ip6_buffer, '/');
-	if (ip6_netmask_buffer) {
-		if (atoi(ip6_netmask_buffer+1) != ip6_netmask) {
-                     warnx("IPv6 address must be a 64-bit mask.");
-                     usage();
+	if (display_ip6_buffer != NULL) {
+
+	    ip6_netmask_buffer = strchr(display_ip6_buffer, '/');
+
+	    if (ip6_netmask_buffer != NULL) {
+		   if (atoi(ip6_netmask_buffer+1) != ip6_netmask) {
+                       warnx("IPv6 address must be a 64-bit mask.");
+                       usage();
 		}
 		/* remove masklen */
 	        memcpy(display_ip6, display_ip6_buffer, strlen(display_ip6_buffer) - strlen(ip6_netmask_buffer)); 
 		display_ip6[strlen(display_ip6)+1] = '\0';
-        }
+	    }
 
-        /* IPV6 address sanity check */
-        if (inet_pton(AF_INET6, display_ip6, &my_ip6) != 1) {
+            /* IPV6 address sanity check */
+            if (inet_pton(AF_INET6, display_ip6, &my_ip6) != 1) {
 		warnx("Bad IPv6 address to use inside tunnel.");
 		usage();
+            }
         }
 
 	topdomain = strdup(argv[1]);
@@ -2753,10 +2757,11 @@ main(int argc, char **argv)
 
 	        }
 
-		if (tun_setip6(display_ip6, display_other_ip6, ip6_netmask) != 0 ) {
-                        retval = 1;
-                        goto cleanup;
-
+		if (display_ip6_buffer != NULL) {
+		    if (tun_setip6(display_ip6, display_other_ip6, ip6_netmask) != 0 ) {
+                          retval = 1;
+                          goto cleanup;
+                    }
 	        }
 
 		if ((mtu < 1280) && (sizeof(display_ip6)) != 0) {

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -666,12 +666,9 @@ static int tunnel_tun(int tun_fd, struct dnsfd *dns_fds)
 	} else { /* IPv6 */
              for (c = 0; c < 16; c++) {
 	        v6Addr.s6_addr[c] = in[c + 28];
-		printf("adding byte: %i to v6 address\n", in[c+28]);
 	     }
 	     inet_ntop(AF_INET6, &v6Addr, v6AddrP, INET6_ADDRSTRLEN);
-	     printf("read v6Addr from tunnel: %s\n", v6AddrP);
 	     userid = find_user_by_ip6(&v6Addr);
-	     printf("userid: %d\n", userid);
         }
 	if (userid < 0)
 		return 0;

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2693,8 +2693,8 @@ main(int argc, char **argv)
 	}
 	if (!skipipconfig) {
 		const char *other_ip = users_get_first_ip();
-		if (tun_setip(argv[0], other_ip, netmask, forward_v6) || tun_setmtu(mtu) != 0) {
-                        retval = 1; 
+		if (tun_setip(argv[0], other_ip, netmask, forward_v6) != 0 || tun_setmtu(mtu) != 0) {
+                        retval = 1;
 			free((void*) other_ip);
                         goto cleanup;
 			

--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2437,7 +2437,7 @@ main(int argc, char **argv)
 	srand(time(NULL));
 	fw_query_init();
 
-	while ((choice = getopt(argc, argv, "46vcsfhDu:t:d:m:l:L:p:n:b:P:z:F:i:")) != -1) {
+	while ((choice = getopt(argc, argv, "46vcsfhDuS:t:d:m:l:L:p:n:b:P:z:F:i:")) != -1) {
 		switch(choice) {
 		case '4':
 			addrfamily = AF_INET;
@@ -2678,11 +2678,17 @@ main(int argc, char **argv)
 	}
 	if (!skipipconfig) {
 		const char *other_ip = users_get_first_ip();
-		if (tun_setip(argv[0], other_ip, netmask, forward_v6) != 0 || tun_setmtu(mtu) != 0) {
-			retval = 1;
+		if (tun_setip(argv[0], other_ip, netmask, forward_v6) || tun_setmtu(mtu) != 0) {
+                        retval = 1; 
 			free((void*) other_ip);
-			goto cleanup;
-		}
+                        goto cleanup;
+			
+	        }
+		if ((mtu < 1280) && (forward_v6)) {
+                                warnx("Interface mtu of %d below the 1280 threshold needed for IPv6 tunneling.\n", mtu);         
+                                warnx("Proceeding without IPv6 tunneling\n");         
+		} 
+
 		free((void*) other_ip);
 	}
 

--- a/src/tun.c
+++ b/src/tun.c
@@ -650,18 +650,20 @@ tun_setip(const char *ip, const char *other_ip, int netbits, int forward_v6)
 # else
 	display_ip = ip;
 # endif
-        fprintf(stderr, "Setting IPv6 of %s to ::%s\n", if_name, ip);
+	if (forward_v6) {
+                fprintf(stderr, "Setting IPv6 of %s to ::%s\n", if_name, ip);
 
-        snprintf(v6_cmdline, sizeof(cmdline),
+                snprintf(v6_cmdline, sizeof(cmdline),
                         IFCONFIGPATH "ifconfig %s inet6 add ::%s/64",
                         if_name,
                         display_ip);
 
-	v6_r = system(v6_cmdline);
+	        v6_r = system(v6_cmdline);
 
-        if (v6_r != 0) {
-            return v6_r;
-        } 
+                if (v6_r != 0) {
+                    return v6_r;
+                } 
+        }
 	snprintf(cmdline, sizeof(cmdline),
 			IFCONFIGPATH "ifconfig %s %s %s netmask %s",
 			if_name,

--- a/src/tun.c
+++ b/src/tun.c
@@ -548,9 +548,9 @@ write_tun(int tun_fd, char *data, size_t len)
 		data += 4;
 		len -= 4;
 	} else {
+                int i = data[4] & 0xf0;
 #ifdef LINUX
 		
-                int i = data[4] & 0xf0;
 		if (i == 64) {
 			fprintf(stderr, "IPv4 packet\n");
 		// Look at the fifth bype 
@@ -581,7 +581,9 @@ write_tun(int tun_fd, char *data, size_t len)
 	    	    data[0] = 0x00;
 		    data[1] = 0x00;
 		    data[2] = 0x00;
-		    data[3] = 0x0A;
+		    data[3] = 0x1E;
+
+                }
 #endif
 	}
 

--- a/src/tun.c
+++ b/src/tun.c
@@ -552,7 +552,6 @@ write_tun(int tun_fd, char *data, size_t len)
 #ifdef LINUX
 		
 		if (i == 64) {
-			fprintf(stderr, "IPv4 packet\n");
 		// Look at the fifth bype 
 		// Linux prefixes with 32 bits ethertype
 		// 0x0800 for IPv4, 0x86DD for IPv6
@@ -561,7 +560,6 @@ write_tun(int tun_fd, char *data, size_t len)
 		    data[2] = 0x08;
 		    data[3] = 0x00;
 	        } else { /* 96 for IPV6 */
-			fprintf(stderr, "IPv6 packet\n");
 	    	    data[0] = 0x00;
 		    data[1] = 0x00;
 		    data[2] = 0x86;
@@ -571,13 +569,11 @@ write_tun(int tun_fd, char *data, size_t len)
 		// BSDs prefix with 32 bits address family
 		// AF_INET for IPv4, AF_INET6 for IPv6
 		if (i == 64) {
-			fprintf(stderr, "IPv4 packet\n");
 	    	    data[0] = 0x00;
 		    data[1] = 0x00;
 		    data[2] = 0x00;
 		    data[3] = 0x02;
 	        } else { /* 96 for IPV6 */
-			fprintf(stderr, "IPv6 packet\n");
 	    	    data[0] = 0x00;
 		    data[1] = 0x00;
 		    data[2] = 0x00;

--- a/src/tun.c
+++ b/src/tun.c
@@ -592,7 +592,7 @@ read_tun(int tun_fd, char *buf, size_t len)
 #endif
 
 int
-tun_setip(const char *ip, const char *other_ip, int netbits)
+tun_setip(const char *ip, const char *other_ip, int netbits, int forward_v6)
 {
 	char cmdline[512];
 	int netmask;
@@ -687,6 +687,15 @@ tun_setip(const char *ip, const char *other_ip, int netbits)
 		if_name, ip, inet_ntoa(net));
 	return system(cmdline);
 #endif
+
+        if (forward_v6) {
+                snprintf(cmdline, sizeof(cmdline),
+                    IFCONFIGPATH "ifconfig %s inet6 add ::%s/64",
+                    if_name,
+                    ip);
+
+        fprintf(stderr, "Setting IP of %s to %s\n", if_name, ip);        
+        }
 }
 
 int

--- a/src/tun.c
+++ b/src/tun.c
@@ -595,9 +595,11 @@ int
 tun_setip(const char *ip, const char *other_ip, int netbits, int forward_v6)
 {
 	char cmdline[512];
+	char v6_cmdline[512];
 	int netmask;
 	struct in_addr net;
 	int i;
+	int v6_r;
 #ifndef LINUX
 	int r;
 #endif
@@ -630,6 +632,18 @@ tun_setip(const char *ip, const char *other_ip, int netbits, int forward_v6)
 # else
 	display_ip = ip;
 # endif
+        fprintf(stderr, "Setting IPv6 of %s to ::%s\n", if_name, ip);
+
+        snprintf(v6_cmdline, sizeof(cmdline),
+                        IFCONFIGPATH "ifconfig %s inet6 add ::%s/64",
+                        if_name,
+                        display_ip);
+
+	v6_r = system(v6_cmdline);
+
+        if (v6_r != 0) {
+            return v6_r;
+        } 
 	snprintf(cmdline, sizeof(cmdline),
 			IFCONFIGPATH "ifconfig %s %s %s netmask %s",
 			if_name,

--- a/src/tun.c
+++ b/src/tun.c
@@ -549,19 +549,39 @@ write_tun(int tun_fd, char *data, size_t len)
 		len -= 4;
 	} else {
 #ifdef LINUX
+		
+                int i = data[4] & 0xf0;
+		if (i == 64) {
+			fprintf(stderr, "IPv4 packet\n");
+		// Look at the fifth bype 
 		// Linux prefixes with 32 bits ethertype
 		// 0x0800 for IPv4, 0x86DD for IPv6
-		data[0] = 0x00;
-		data[1] = 0x00;
-		data[2] = 0x08;
-		data[3] = 0x00;
+	    	    data[0] = 0x00;
+		    data[1] = 0x00;
+		    data[2] = 0x08;
+		    data[3] = 0x00;
+	        } else { /* 96 for IPV6 */
+			fprintf(stderr, "IPv6 packet\n");
+	    	    data[0] = 0x00;
+		    data[1] = 0x00;
+		    data[2] = 0x86;
+		    data[3] = 0xDD;
+	       }	
 #else /* OPENBSD and DARWIN(utun) */
 		// BSDs prefix with 32 bits address family
 		// AF_INET for IPv4, AF_INET6 for IPv6
-		data[0] = 0x00;
-		data[1] = 0x00;
-		data[2] = 0x00;
-		data[3] = 0x02;
+		if (i == 64) {
+			fprintf(stderr, "IPv4 packet\n");
+	    	    data[0] = 0x00;
+		    data[1] = 0x00;
+		    data[2] = 0x00;
+		    data[3] = 0x02;
+	        } else { /* 96 for IPV6 */
+			fprintf(stderr, "IPv6 packet\n");
+	    	    data[0] = 0x00;
+		    data[1] = 0x00;
+		    data[2] = 0x00;
+		    data[3] = 0x0A;
 #endif
 	}
 

--- a/src/tun.h
+++ b/src/tun.h
@@ -22,7 +22,9 @@ int open_tun(const char *);
 void close_tun(int);
 int write_tun(int, char *, size_t);
 ssize_t read_tun(int, char *, size_t);
-int tun_setip(const char *, const char *, int, int);
+int tun_setip(const char *, const char *, int);
+int tun_setip6(char *, const char *, int);
 int tun_setmtu(const unsigned);
+int get_ipversion(char);
 
 #endif /* _TUN_H_ */

--- a/src/tun.h
+++ b/src/tun.h
@@ -22,7 +22,7 @@ int open_tun(const char *);
 void close_tun(int);
 int write_tun(int, char *, size_t);
 ssize_t read_tun(int, char *, size_t);
-int tun_setip(const char *, const char *, int);
+int tun_setip(const char *, const char *, int, int);
 int tun_setmtu(const unsigned);
 
 #endif /* _TUN_H_ */

--- a/src/user.c
+++ b/src/user.c
@@ -44,7 +44,6 @@ int init_users(in_addr_t my_ip, int netbits)
 	char newip[16];
 	char ip6Tmp[16];
 	char ip6Tmp2[18];
-        char ipv4Tmp[16];
 
 	int maxusers;
 
@@ -71,7 +70,12 @@ int init_users(in_addr_t my_ip, int netbits)
 	for (i = 0; i < usercount; i++) {
 		in_addr_t ip;
 		users[i].id = i;
+
+		memset(ip6Tmp,0,strlen(ip6Tmp)); 
+		memset(ip6Tmp2,0,strlen(ip6Tmp2)); 
+
 		snprintf(newip, sizeof(newip), "0.0.0.%d", i + skip + 1);
+
 		ip = ipstart.s_addr + inet_addr(newip);
 		if (ip == my_ip && skip == 0) {
 			/* This IP was taken by iodined */
@@ -79,18 +83,14 @@ int init_users(in_addr_t my_ip, int netbits)
 			snprintf(newip, sizeof(newip), "0.0.0.%d", i + skip + 1);
 			ip = ipstart.s_addr + inet_addr(newip);
 
-			inet_ntop(AF_INET, &ip, ip6Tmp, INET_ADDRSTRLEN);
-
-			snprintf(ip6Tmp2, sizeof(ip6Tmp2), "::%s", ip6Tmp);
-                        
-			inet_pton(AF_INET6, ip6Tmp2, &users[i].tun_ip6);
-			memset(ip6Tmp2,0,strlen(ip6Tmp2)); 
-			inet_ntop(AF_INET6, &users[i].tun_ip6, ip6Tmp2, INET6_ADDRSTRLEN); 
-			inet_ntop(AF_INET, &ip, ipv4Tmp, INET_ADDRSTRLEN); 
-			memset(ip6Tmp2,0,strlen(ip6Tmp2)); 
 			
 		}
 		users[i].tun_ip = ip;
+
+		inet_ntop(AF_INET, &ip, ip6Tmp, INET_ADDRSTRLEN);
+		snprintf(ip6Tmp2, sizeof(ip6Tmp2), "::%s", ip6Tmp);
+		inet_pton(AF_INET6, ip6Tmp2, &users[i].tun_ip6);
+		
 		net.s_addr = ip;
 		users[i].disabled = 0;
 		users[i].authenticated = 0;

--- a/src/user.c
+++ b/src/user.c
@@ -119,7 +119,6 @@ int find_user_by_ip6(struct in6_addr *v6Addr)
 
 	inet_ntop(AF_INET6, v6Addr, v6AddrOut, INET6_ADDRSTRLEN);
 
-	printf("Going to check address: %s in user list\n", v6AddrOut);
 	for (i = 0; i < usercount; i++) {
 		if (users[i].active &&
 			users[i].authenticated &&
@@ -137,7 +136,6 @@ int areV6AddressesEqual(struct in6_addr *v6Struct1, struct in6_addr *v6Struct2)
         int i;
     
 	for (i = 0; i < 16; i++) {
-		printf("byte1 %d: %d byte2 %d: %d\n", i, v6Struct1->s6_addr[i], i, v6Struct2->s6_addr[i]);
 		if (v6Struct1->s6_addr[i] != v6Struct2->s6_addr[i]) {
 		    return -1;
 		}

--- a/src/user.c
+++ b/src/user.c
@@ -87,8 +87,6 @@ int init_users(in_addr_t my_ip, int netbits)
 			memset(ip6Tmp2,0,strlen(ip6Tmp2)); 
 			inet_ntop(AF_INET6, &users[i].tun_ip6, ip6Tmp2, INET6_ADDRSTRLEN); 
 			inet_ntop(AF_INET, &ip, ipv4Tmp, INET_ADDRSTRLEN); 
-	                printf("storing IPv4 address: %s\n", ipv4Tmp);
-	                printf("storing IPv6 address: %s\n", ip6Tmp2);
 			memset(ip6Tmp2,0,strlen(ip6Tmp2)); 
 			
 		}

--- a/src/user.h
+++ b/src/user.h
@@ -45,6 +45,7 @@ struct tun_user {
 	int seed;
 	in_addr_t tun_ip;
 	struct sockaddr_storage host;
+	struct in6_addr tun_ip6;
 	socklen_t hostlen;
 	struct query q;
 	struct query q_sendrealsoon;
@@ -83,9 +84,11 @@ extern struct tun_user *users;
 int init_users(in_addr_t, int);
 const char* users_get_first_ip(void);
 int find_user_by_ip(uint32_t);
+int find_user_by_ip6(struct in6_addr *v6Addr);
 int all_users_waiting_to_send(void);
 int find_available_user(void);
 void user_switch_codec(int userid, const struct encoder *enc);
 void user_set_conn_type(int userid, enum connection c);
+int areV6AddressesEqual(struct in6_addr *, struct in6_addr *);
 
 #endif

--- a/src/user.h
+++ b/src/user.h
@@ -81,14 +81,15 @@ struct tun_user {
 
 extern struct tun_user *users;
 
-int init_users(in_addr_t, int);
+int init_users(in_addr_t, int, struct in6_addr, int);
 const char* users_get_first_ip(void);
+const char* users_get_first_ip6(void);
 int find_user_by_ip(uint32_t);
 int find_user_by_ip6(struct in6_addr *v6Addr);
 int all_users_waiting_to_send(void);
 int find_available_user(void);
 void user_switch_codec(int userid, const struct encoder *enc);
 void user_set_conn_type(int userid, enum connection c);
-int areV6AddressesEqual(struct in6_addr *, struct in6_addr *);
+bool v6AddressesEqual(struct in6_addr *, struct in6_addr *);
 
 #endif


### PR DESCRIPTION
1. Adds a new -S flag to both iodine and iodined to indicate desire to forward IPv6 packets within the tunnel
2. If V6 tunnel forwarding is requested (i.e. forward IPv6 packets within the tunnel and the tunnel interface comes up, add an IPv6 address to the interface.
    a) The IPv6 address is the same as the IPv4 tunnel address but in the form ::<IPv4 tunnel address>/64. The mask is always /64 and is configured on the interface using ifconfig/ipconfig (WINDOWS32 ipconfig support pending).
3. Fix a bug with getopt() where the last option in the list of options that don't take an argument was being ignored. 
4. The patch does not explicitly block IPv6 forwarding across the tunnel. So connecting to an automatically generated link-local address at the other end, i.e. fe80::x should work. This allows users to install iodine regardless of underlying OS IPv6 support and not break anything (as long as -S is not specified on the command line).
5. Tested on both LINUX and DARWIN. Not tested on WINDOWS32. 