### PR TITLE
allow to override Makefile TARGETOS variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ MKDIR_FLAGS=-p
 RM=rm
 RM_FLAGS=-f
 
-TARGETOS = `uname`
+TARGETOS ?= `uname`
 
 all:
 	@$(MAKE) -C src TARGETOS=$(TARGETOS) all


### PR DESCRIPTION
Overriding TARGETOS is useful for cross-compiling if build OS and
target OS are different (e.g. build on MacOS for Linux)

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>