### PR TITLE
Build Issue on FreeBSD: tzsetwall() is deprecated, use tzset() instead.

### DIFF
--- a/src/iodined.c
+++ b/src/iodined.c
@@ -2754,7 +2754,7 @@ main(int argc, char **argv)
 		do_pidfile(pidfile);
 
 #ifdef FREEBSD
-	tzsetwall();
+	tzset();
 #endif
 #ifndef WINDOWS32
 	openlog(__progname, LOG_NDELAY, LOG_DAEMON);


### PR DESCRIPTION
I am currently attempting to update the iodine package on FreeBSD to version 0.8.0. However, there is a bug that I have encountered where tzset is incorrectly set to tzsetwall. To fix this issue, I have submitted a pull request to address the problem.

/usr/ports/net/iodine/work/iodine-0.8.0/src/iodined.c:2757: warning: warning: tzsetwall() is deprecated, use tzset() instead.