### PR TITLE
src/osflags: fully fix cross-compilation

### DIFF
--- a/src/osflags
+++ b/src/osflags
@@ -20,7 +20,7 @@ link)
 		;;
 		Linux)
 			FLAGS="";
-			[ -e /usr/include/selinux/selinux.h ] && FLAGS="$FLAGS -lselinux";
+			"$PKG_CONFIG" --exists libselinux && FLAGS="$FLAGS $($PKG_CONFIG --libs libselinux)";
 			"$PKG_CONFIG" --exists libsystemd-daemon && FLAGS="$FLAGS $($PKG_CONFIG --libs libsystemd-daemon)";
 			"$PKG_CONFIG" --exists libsystemd && FLAGS="$FLAGS $($PKG_CONFIG --libs libsystemd)";
 			echo $FLAGS;
@@ -40,7 +40,7 @@ cflags)
 		;;
 		Linux)
 			FLAGS="-D_GNU_SOURCE"
-			[ -e /usr/include/selinux/selinux.h ] && FLAGS="$FLAGS -DHAVE_SETCON";
+			"$PKG_CONFIG" --exists libselinux && FLAGS="$FLAGS -DHAVE_SETCON";
 			"$PKG_CONFIG" --exists libsystemd-daemon && FLAGS="$FLAGS -DHAVE_SYSTEMD";
 			"$PKG_CONFIG" --exists libsystemd && FLAGS="$FLAGS -DHAVE_SYSTEMD";
 			echo $FLAGS;


### PR DESCRIPTION
Cross-compilation was only partially fixed by https://github.com/yarrick/iodine/commit/024481c94b97ef37981621cdc38f8b20f8919418 as selinux was still enabled depending on host file existence