### PR TITLE
Answer NXDOMAIN for _.xxx.yyy.top.domain

### DIFF
--- a/src/dns.h
+++ b/src/dns.h
@@ -31,6 +31,7 @@ int dns_encode(char *, size_t, struct query *, qr_t, const char *, size_t);
 int dns_encode_ns_response(char *buf, size_t buflen, struct query *q,
 			   char *topdomain);
 int dns_encode_a_response(char *buf, size_t buflen, struct query *q);
+int dns_encode_nxdomain(char *buf, size_t buflen, struct query *q, const char *zone);
 unsigned short dns_get_id(char *packet, size_t packetlen);
 int dns_decode(char *, size_t, struct query *, qr_t, char *, size_t);
 

--- a/src/windows.h
+++ b/src/windows.h
@@ -40,6 +40,7 @@ typedef unsigned int in_addr_t;
 #define T_CNAME DNS_TYPE_CNAME
 #define T_MX DNS_TYPE_MX
 #define T_TXT DNS_TYPE_TXT
+#define T_SOA DNS_TYPE_SOA
 #define T_SRV DNS_TYPE_SRV
 
 #define C_IN 1


### PR DESCRIPTION
When a DNS query name is too long, it is split into multiple domain components. However, recursive DNS servers that implement QNAME minimization may query each subdomain individually without revealing the full name.  As part of this behavior, they often send a preliminary query for a hostname like "_" before attempting to resolve the full name.  If this query is not handled correctly, it can lead to timeouts and failed connections.  The most effective way to avoid this is to respond with an NXDOMAIN for such queries.