### PR TITLE
Allow longer nameservers.

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -21,10 +21,10 @@
 
 char *get_resolvconf_addr(void)
 {
-	static char addr[16];
+	static char addr[257];
 	char *rv = NULL;
 #ifndef WINDOWS32
-	char buf[80];
+	char buf[257];
 	FILE *fp;
 #ifdef ANDROID
 	fp = popen("getprop net.dns1", "r");
@@ -32,7 +32,7 @@ char *get_resolvconf_addr(void)
 		err(1, "getprop net.dns1 failed");
 	if (fgets(buf, sizeof(buf), fp) == NULL)
 		err(1, "read getprop net.dns1 failed");
-	if (sscanf(buf, "%15s", addr) == 1)
+	if (sscanf(buf, "%256s", addr) == 1)
 		rv = addr;
 	pclose(fp);
 #else
@@ -42,7 +42,7 @@ char *get_resolvconf_addr(void)
 	while (feof(fp) == 0) {
 		fgets(buf, sizeof(buf), fp);
 
-		if (sscanf(buf, "nameserver %15s", addr) == 1) {
+		if (sscanf(buf, "nameserver %256s", addr) == 1) {
 			rv = addr;
 			break;
 		}


### PR DESCRIPTION
IPv6 nameservers can be significantly longer than 16 characters in length. For example, `2001:0db8:85a3:0000:0000:8a2e:0370:7334` is 39 characters long, and certain syntax elements (e.g. zone indices) can make them even longer.

This patch allows up to 256 characters for the nameserver, which is large enough to contain the maximum length of any hostname (~253 ASCII characters), and definitely enough for any IPv4 or IPv6 address.

## Testing

I am using an IPv6 nameserver whose IP address is longer than 16 bytes. Without this patch, I get the error `iodine: Cannot lookup nameserver '2001:db8:85a3:0': Unknown error`. With this patch, Iodine works correctly.

Note that the `Unknown error` part occurs because my getaddrinfo returns 8 ("nodename nor servname provided, or not known") but this gets translated into -1 by `get_addr`, and then -1 gets passed into `gai_strerror`. This is unfortunate as the actual error gets swallowed; a potentially better error handling strategy would be to return `addrlen` in a pointer parameter and have only 0 be a successful result, but this would necessitate a number of changes throughout the code.